### PR TITLE
Adds stake min hyper param.

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -118,6 +118,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type InitialStakePruningDenominator: Get<u64>;
 
+		/// Initial stake pruning min
+		#[pallet::constant]
+		type InitialStakePruningMin: Get<u64>;
+
 		/// Initial incentive pruning denominator
 		#[pallet::constant]
 		type InitialIncentivePruningDenominator: Get<u64>;
@@ -331,6 +335,16 @@ pub mod pallet {
 		u64, 
 		ValueQuery,
 		DefaultStakePruningDenominator<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultStakePruningMin<T: Config>() -> u64 { T::InitialStakePruningMin::get() }
+	#[pallet::storage]
+	pub type StakePruningMin<T> = StorageValue<
+		_, 
+		u64, 
+		ValueQuery,
+		DefaultStakePruningMin<T>
 	>;
 
 	#[pallet::type_value] 
@@ -720,6 +734,9 @@ pub mod pallet {
 
 		/// --- Event created when the stake pruning denominator has been set.
 		StakePruningDenominatorSet( u64 ),
+
+		/// --- Event created when the stake pruning min has been set.
+		StakePruningMinSet( u64 ),
 
 		/// --- Event created when the foundation account has been set.
 		FoundationAccountSet( T::AccountId ),
@@ -1291,6 +1308,16 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_stake_pruning_min( 
+			origin:OriginFor<T>, 
+			stake_pruning_min: u64 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+			StakePruningMin::<T>::set( stake_pruning_min );
+			Self::deposit_event( Event::StakePruningMinSet( stake_pruning_min ));
+			Ok(())
+		}
 
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
 		pub fn sudo_set_immunity_period ( 
@@ -1409,6 +1436,12 @@ pub mod pallet {
 		}
 		pub fn set_stake_pruning_denominator( stake_pruning_denominator: u64 ) {
 			StakePruningDenominator::<T>::put( stake_pruning_denominator );
+		}
+		pub fn get_stake_pruning_min( ) -> u64 {
+			return StakePruningMin::<T>::get();
+		}
+		pub fn set_stake_pruning_min( stake_pruning_min: u64 ) {
+			StakePruningMin::<T>::put( stake_pruning_min );
 		}
 
 		pub fn get_validator_sequence_length( ) -> u64 {

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -77,7 +77,7 @@ impl<T: Config> Pallet<T> {
                 // the min incentive proportion. 
                 // Calculate stake proportion with zero check.        
                 let mut stake_proportion: I65F63;
-                if Self::get_total_stake() == 0 {
+                if Self::get_total_stake() == 0 || neuron_i.stake <= Self::get_stake_pruning_min() {
                     stake_proportion = I65F63::from_num( u64::min_value() );
                 } else {
                     stake_proportion = I65F63::from_num( neuron_i.stake ) / I65F63::from_num( Self::get_total_stake() ); // Stake proportion (0, 1)

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -87,6 +87,7 @@ parameter_types! {
 	pub const InitialBondsMovingAverage: u64 = 500_000;
 	pub const InitialIncentivePruningDenominator: u64 = 1;
 	pub const InitialStakePruningDenominator: u64 = 1;
+	pub const InitialStakePruningMin: u64 = 0;
 	pub const InitialFoundationDistribution: u64 = 0;
 
 	pub const InitialValidatorBatchSize: u64 = 10;
@@ -199,6 +200,7 @@ impl pallet_subtensor::Config for Test {
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
+	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;
 	type InitialFoundationDistribution = InitialFoundationDistribution;
 	type InitialIssuance = InitialIssuance;

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -153,6 +153,15 @@ fn test_sudo_stake_pruning_denominator() {
     });
 }
 
+#[test]
+fn test_sudo_stake_pruning_min() {
+	new_test_ext().execute_with(|| {
+        let stake_pruning_min: u64 = 10;
+		assert_ok!(Subtensor::sudo_set_stake_pruning_min(<<Test as Config>::Origin>::root(), stake_pruning_min));
+        assert_eq!(Subtensor::get_stake_pruning_min(), stake_pruning_min);
+    });
+}
+
 
 #[test]
 fn test_sudo_max_allowed_uids() {
@@ -362,6 +371,16 @@ fn test_fails_sudo_set_stake_pruning_denominator() {
         let init_stake_pruning_denominator: u64 = Subtensor::get_stake_pruning_denominator();
 		assert_eq!(Subtensor::sudo_set_stake_pruning_denominator(<<Test as Config>::Origin>::signed(0), stake_pruning_denominator),  Err(DispatchError::BadOrigin.into()));
         assert_eq!(Subtensor::get_stake_pruning_denominator(), init_stake_pruning_denominator);
+    });
+}
+
+#[test]
+fn test_fails_sudo_set_stake_pruning_min() {
+	new_test_ext().execute_with(|| {
+        let stake_pruning_min: u64 = 10;
+        let init_stake_pruning_min: u64 = Subtensor::get_stake_pruning_min();
+		assert_eq!(Subtensor::sudo_set_stake_pruning_min(<<Test as Config>::Origin>::signed(0), stake_pruning_min),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_stake_pruning_min(), init_stake_pruning_min);
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 105,
+	spec_version: 108,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -284,6 +284,7 @@ parameter_types! {
 	pub const InitialBondsMovingAverage: u64 = 900_000;
 	pub const InitialIncentivePruningDenominator: u64 = 1;
 	pub const InitialStakePruningDenominator: u64 = 1;
+	pub const InitialStakePruningMin: u64 = 0;
 	pub const InitialFoundationDistribution: u64 = 0;
 	pub const InitialDifficulty: u64 = 10000000;
 	pub const MinimumDifficulty: u64 = 10000000;
@@ -313,6 +314,7 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
+	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;
 	type InitialFoundationDistribution = InitialFoundationDistribution;
 	type InitialBlocksPerStep = InitialBlocksPerStep;


### PR DESCRIPTION
relevant change is:
                if Self::get_total_stake() == 0 || neuron_i.stake <= Self::get_stake_pruning_min() {
                    stake_proportion = I65F63::from_num( u64::min_value() );
                } else {
                    stake_proportion = I65F63::from_num( neuron_i.stake ) / I65F63::from_num( Self::get_total_stake() ); // Stake proportion (0, 1)
                }
