### PR TITLE
Increasing minAllowedWeights from 600 to 1024

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -9,7 +9,7 @@
 | **kappa**                          | 2         |
 | **maxAllowedMaxMinRatio**          | 10        |
 | **maxAllowedUids**                 | 4096      |
-| **minAllowedWeights**              | 600       |
+| **minAllowedWeights**              | 1024      |
 | **rho**                            | 10        |
 | **stakePruningDenominator**        | 20        |
 | **stakePruningMin**                | 300       |


### PR DESCRIPTION
Param: minAllowedWeights
Initial Value: 600
Suggested Value: 1024
Time of Effect: Immediate

Background:
By the whitepaper definition, the network has reached consensus when the majority of incentives are accrued to peers with trust exceeding 50% of the stake weight. The whitepaper outlines in some detail how this point creates deflationary pressure on a disjoint cabal.  We compute the distance from this point (below) showing a result of 0.5 which suggests the network is strongly out of consensus. Note: negative or zero values are desirable.

>>> 0.5 - meta.I[ meta.T > 0.5 ].sum() = 0.5

Motivation for suggested change:

A peer's naive trust score is calculated by summing the number of inward non-zero weights. As a result, the total number of non-zero edges in the network, a.k.a the density of the weight matrix, directly reflects the expected trust scores for peers. 

We recompute the consensus point with trust scores multiplied by the factor (1024/600) to simulate the effect of the change.
>>>  0.5 - meta.I[ meta.T*(1024/600) > 0.5 ].sum() = 0.27