### PR TITLE
Update max allowed max min ratio

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -7,7 +7,7 @@
 | **immunityPeriod**                 | 2048      |
 | **incentivePruningDenominator**    | 1         |
 | **kappa**                          | 2         |
-| **maxAllowedMaxMinRatio**          | 10        |
+| **maxAllowedMaxMinRatio**          | 64        |
 | **maxAllowedUids**                 | 4096      |
 | **minAllowedWeights**              | 600       |
 | **rho**                            | 10        |


### PR DESCRIPTION
Param: maxallowedmaxminratio
Initial Value: 10
Suggested Value: 64
Time of Effect: Immediate

Background/Reasoning:
The original functionality of `normalize_max_multiple` and `maxallowedmaxminratio` was to reduce the power of outliers in the validation. The process of validation has now changed due to the synapse update. We are updating the parameter to reflect these changes