### PR TITLE
Increase stake pruning min

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -12,7 +12,7 @@
 | **minAllowedWeights**              | 600       |
 | **rho**                            | 10        |
 | **stakePruningDenominator**        | 20        |
-| **stakePruningMin**                | 300       |
+| **stakePruningMin**                | 512       |
 | **targetRegistrationsPerInterval** | 2         |
 | **validatorBatchSize**             | 32        |
 | **validatorEpochLen**              | 250       |


### PR DESCRIPTION
**BIT-increase-stakepruningmin**

**Abstract**
The stake pruning min is the minimum needed amount of tao staked by a miner to stay registered in the network without contributing useful information. If a node is inactive and is not holding tao that is equal to or less than the `stakePruningMin` then it will be kicked out of the network once another node registers. By changing the stake pruning min to be higher, we are making it so that you need more tao to stay registered.

**Motivation**
This is being changed so that we can prune out any inactive miners receiving rewards without actually contributing anything useful. 

**Specification**
_Param_: stakepruningmin
_Initial Value_: 300
_Suggested Value_: 512
_Time of Effect_: Immediate