### PR TITLE
Increase Sequence Length & Decrease BatchSize

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -14,8 +14,8 @@
 | **stakePruningDenominator**        | 20        |
 | **stakePruningMin**                | 300       |
 | **targetRegistrationsPerInterval** | 2         |
-| **validatorBatchSize**             | 32        |
+| **validatorBatchSize**             | 16        |
 | **validatorEpochLen**              | 250       |
 | **validatorEpochsPerReset**        | 60        |
-| **validatorSequenceLength**        | 64        |
+| **validatorSequenceLength**        | 128       |
 


### PR DESCRIPTION
The current setup favours small models due to the short sequence length, but also forces operators to use smaller models due to the high batch size. Longer sequence lengths means that bigger AI models have a better chance for doing one-shots, and since bigger AI models can handle at least 1024 tokens, this should eventually be pushed to the maximum size for the biggest models (2048).
 
This PR also decreases the amount of requests being sent to miners, since increasing batch size or sequence length increases the memory burden on miners. Decreasing batch size also decreases the repetition on models, making the power usage lower and also making it possible for bigger models to reply on smaller hardware.

This PR is not aimed at creating a bigger burden for GPU's, but rather aimed at making bigger models more favourable due to the longer input to be used for the one-shot.