### PR TITLE
Increase stakePruningMin to 1024

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -12,7 +12,7 @@
 | **minAllowedWeights**              | 1024      |
 | **rho**                            | 10        |
 | **stakePruningDenominator**        | 20        |
-| **stakePruningMin**                | 512       |
+| **stakePruningMin**                | 1024      |
 | **targetRegistrationsPerInterval** | 2         |
 | **validatorBatchSize**             | 32        |
 | **validatorEpochLen**              | 250       |


### PR DESCRIPTION
BIT-increase-stake-pruning-min-to-1024

Abstract
The stake pruning min is the minimum needed amount of tao staked by a miner to stay registered in the network without contributing useful information. If a node is inactive and is not holding Tao that is equal to or less than the stakePruningMin then it will be kicked out of the network once another node registers. By changing the stake pruning min to be higher, we are making it so that you need more tao to stay registered.

Motivation
This is being changed so that we can prune out any inactive miners receiving rewards without actually contributing anything useful.

Specification
Param: stakepruningmin
Initial Value:512
Suggested Value:1024
Time of Effect: Immediate