### PR TITLE
BTP-01-minAllowedWeights: 1024->1536

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -9,7 +9,7 @@
 | **kappa**                          | 2         |
 | **maxAllowedMaxMinRatio**          | 64        |
 | **maxAllowedUids**                 | 4096      |
-| **minAllowedWeights**              | 1024      |
+| **minAllowedWeights**              | 1536      |
 | **rho**                            | 10        |
 | **stakePruningDenominator**        | 20        |
 | **stakePruningMin**                | 512       |


### PR DESCRIPTION
Abstract
The minAllowedWeights determine the number of weights set by each validator. Overall, increasing this parameter will increase the overall trust in the network. Increasing the number of weights available on the network should lead to a higher trust for the average server and a higher consensus.

Motivation
While change #4 increased the overall trust from T=~0.15 to T=~0.3, there is still room for growth. Currently, only ~30% of the incentive are earned by peers with T>0.5, as opposed to the 50% described in the white paper. We also noticed that the default number of weights was too low compared to the number of weights expected in the latest update. Therefore we are increasing the minAllowedWeights to compensate for this discrepancy

Specification
Param: minAllowedWeights
Initial Value:1024
Suggested Value:1536
Time of Effect: Immediate