### PR TITLE
BTP-02-validatorEpochLen: 250->350

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -15,7 +15,7 @@
 | **stakePruningMin**                | 512       |
 | **targetRegistrationsPerInterval** | 2         |
 | **validatorBatchSize**             | 32        |
-| **validatorEpochLen**              | 250       |
+| **validatorEpochLen**              | 350       |
 | **validatorEpochsPerReset**        | 60        |
 | **validatorSequenceLength**        | 64        |
 


### PR DESCRIPTION
Abstract
The validatorEpochLen determines the number of blocks per epoch for each validator. This parameter controls how often each validator will set its weights. Previously, each validator had 250 blocks to query the network, before submitting their weights to the chain.

Motivation
-A potential parameter change in response to the increase of weights ( #11 ) that are required by the chain. This change will give slower validators more time to query the network before submitting their weights. Further analysis will determine if this change is necessary.

Specification
Param: validatorEpochLen
Initial Value:250
Suggested Value:350
Time of Effect: If needed, after #11 has been merged