### PR TITLE
Auto decay moving average bonds

### DIFF
--- a/pallets/subtensor/src/step.rs
+++ b/pallets/subtensor/src/step.rs
@@ -219,9 +219,10 @@ impl<T: Config> Pallet<T> {
                 // Prunning occurs here. We simply to do fill this bonds matrix 
                 // with entries that contain the uids to prune. 
                 if !NeuronsToPruneAtNextEpoch::<T>::contains_key(uid_j) {
-                    // Otherwise, we add the entry into the stack based bonds array.
-                    bonds_row [ *uid_j as usize ] = *bonds_ij;
-                    bond_totals [ *uid_j as usize ] += *bonds_ij;
+                    // Otherwise, we add the entry into the stack based bonds array. We decay here as an optimization.
+                    let decayed_bond_ij: u64 = (bonds_moving_average * I65F63::from_num( *bonds_ij )).to_num::<u64>();
+                    bonds_row [ *uid_j as usize ] = *decayed_bond_ij;
+                    bond_totals [ *uid_j as usize ] += *decayed_bond_ij;
                 }
 
             }
@@ -283,17 +284,17 @@ impl<T: Config> Pallet<T> {
                 total_trust += trust_increment_ij;  // Range( 0, total_active_stake )
                 
                 // === Compute bonding moving averages ===
-                let prev_bonds_ij: I65F63 = I65F63::from_num( bonds[ *uid_i as usize  ][ *uid_j as usize ] );
-                let moving_average_bonds_ij = bonds_moving_average * prev_bonds_ij + ( one - bonds_moving_average ) * bond_increment_ij;
+                let prev_decayed_bonds_ij: I65F63 = I65F63::from_num( bonds[ *uid_i as usize  ][ *uid_j as usize ] );
+                let moving_average_bonds_ij = prev_decayed_bonds_ij + ( one - bonds_moving_average ) * bond_increment_ij;
                 bonds [ *uid_i as usize  ][ *uid_j as usize ] = moving_average_bonds_ij.to_num::<u64>(); // Range( 0, block_emission )
 
                 // === Update bond totals ===
-                if prev_bonds_ij >= moving_average_bonds_ij {
-                    bond_totals [ *uid_j as usize ] -= ( prev_bonds_ij - moving_average_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
-                    total_bonds_purchased = ( prev_bonds_ij - moving_average_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
+                if prev_decayed_bonds_ij >= moving_average_bonds_ij {
+                    bond_totals [ *uid_j as usize ] -= ( prev_decayed_bonds_ij - moving_average_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
+                    total_bonds_purchased = ( prev_decayed_bonds_ij - moving_average_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
                 } else {
-                    bond_totals [ *uid_j as usize ] += ( moving_average_bonds_ij - prev_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
-                    total_bonds_purchased = ( moving_average_bonds_ij - prev_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
+                    bond_totals [ *uid_j as usize ] += ( moving_average_bonds_ij - prev_decayed_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
+                    total_bonds_purchased = ( moving_average_bonds_ij - prev_decayed_bonds_ij ).to_num::<u64>(); // Range( 0, block_emission )
                 }
             }
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 108,
+	spec_version: 109,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Adds auto decaying bonds in moving average calculation to avoid issues where bonds with no weights are unchanged.
Requires chain upgrade.
