### PR TITLE
Adds a max clip value to replace the max allowed min max ratio

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -114,9 +114,9 @@ pub mod pallet {
 		#[pallet::constant]
 		type InitialMaxAllowedMaxMinRatio: Get<u64>;
 
-		/// Initial allowed max weight value.
+		/// Initial max weight limit.
 		#[pallet::constant]
-		type InitialMaxWeightValue: Get<u32>;
+		type InitialMaxWeightLimit: Get<u32>;
 
 		/// Initial stake pruning denominator
 		#[pallet::constant]
@@ -423,13 +423,13 @@ pub mod pallet {
 	>;
 
 	#[pallet::type_value] 
-	pub fn DefaultMaxWeightValue<T: Config>() -> u32 { T::InitialMaxWeightValue::get() }
+	pub fn DefaultMaxWeightLimit<T: Config>() -> u32 { T::InitialMaxWeightLimit::get() }
 	#[pallet::storage]
-	pub type MaxWeightValue<T> = StorageValue<
+	pub type MaxWeightLimit<T> = StorageValue<
 		_, 
 		u32, 
 		ValueQuery,
-		DefaultMaxWeightValue<T>
+		DefaultMaxWeightLimit<T>
 	>;
 
 	#[pallet::type_value] 
@@ -743,8 +743,8 @@ pub mod pallet {
 		/// --- Event created when the max allowed max min ration has been set.
 		MaxAllowedMaxMinRatioSet( u64 ),
 
-		/// --- Event created when the max weight value has been set.
-		MaxWeightValueSet( u32 ),
+		/// --- Event created when the max weight limit has been set.
+		MaxWeightLimitSet( u32 ),
 
 		/// --- Event created when the incentive pruning denominator has been set.
 		IncentivePruningDenominatorSet( u64 ),
@@ -859,8 +859,8 @@ pub mod pallet {
 		/// max value is more than MaxAllowedMaxMinRatio.
 		MaxAllowedMaxMinRatioExceeded,
 
-		/// ---- Thrown when the dispatch attempts to set weights on chain with where the normalized
-		/// max value is more than MaxWeightValue.
+		/// ---- Thrown when the dispatch attempts to set weights on chain with where any normalized
+		/// weight is more than MaxWeightLimit.
 		MaxWeightExceeded,
 
 		/// ---- Thrown when the caller attempts to use a repeated work.
@@ -1264,13 +1264,13 @@ pub mod pallet {
 		}
 
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-		pub fn sudo_set_max_weight_value ( 
+		pub fn sudo_set_max_weight_limit ( 
 			origin:OriginFor<T>, 
-			max_weight_value: u32 
+			max_weight_limit: u32 
 		) -> DispatchResult {
 			ensure_root( origin )?;
-			MaxWeightValue::<T>::set( max_weight_value );
-			Self::deposit_event( Event::MaxWeightValueSet( max_weight_value ) );
+			MaxWeightLimit::<T>::set( max_weight_limit );
+			Self::deposit_event( Event::MaxWeightLimitSet( max_weight_limit ) );
 			Ok(())
 		}
 
@@ -1532,11 +1532,11 @@ pub mod pallet {
 		pub fn set_max_allowed_max_min_ratio( max_allowed_max_min_ratio: u64 ) {
 			MaxAllowedMaxMinRatio::<T>::put( max_allowed_max_min_ratio );
 		}
-		pub fn get_max_weight_value( ) -> u32 {
-			return MaxWeightValue::<T>::get();
+		pub fn get_max_weight_limit( ) -> u32 {
+			return MaxWeightLimit::<T>::get();
 		}
-		pub fn set_max_weight_value( max_weight_value: u32 ) {
-			MaxWeightValue::<T>::put( max_weight_value );
+		pub fn set_max_weight_limit( max_weight_limit: u32 ) {
+			MaxWeightLimit::<T>::put( max_weight_limit );
 		}
 		pub fn get_immunity_period( ) -> u64 {
 			return ImmunityPeriod::<T>::get();

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -114,9 +114,9 @@ pub mod pallet {
 		#[pallet::constant]
 		type InitialMaxAllowedMaxMinRatio: Get<u64>;
 
-		/// Initial allowed max clip value.
+		/// Initial allowed max weight value.
 		#[pallet::constant]
-		type InitialMaxClipValue: Get<u32>;
+		type InitialMaxWeightValue: Get<u32>;
 
 		/// Initial stake pruning denominator
 		#[pallet::constant]
@@ -423,13 +423,13 @@ pub mod pallet {
 	>;
 
 	#[pallet::type_value] 
-	pub fn DefaultMaxClipValue<T: Config>() -> u32 { T::InitialMaxClipValue::get() }
+	pub fn DefaultMaxWeightValue<T: Config>() -> u32 { T::InitialMaxWeightValue::get() }
 	#[pallet::storage]
-	pub type MaxClipValue<T> = StorageValue<
+	pub type MaxWeightValue<T> = StorageValue<
 		_, 
 		u32, 
 		ValueQuery,
-		DefaultMaxClipValue<T>
+		DefaultMaxWeightValue<T>
 	>;
 
 	#[pallet::type_value] 
@@ -743,8 +743,8 @@ pub mod pallet {
 		/// --- Event created when the max allowed max min ration has been set.
 		MaxAllowedMaxMinRatioSet( u64 ),
 
-		/// --- Event created when the max clip value has been set.
-		MaxClipValueSet( u32 ),
+		/// --- Event created when the max weight value has been set.
+		MaxWeightValueSet( u32 ),
 
 		/// --- Event created when the incentive pruning denominator has been set.
 		IncentivePruningDenominatorSet( u64 ),
@@ -860,8 +860,8 @@ pub mod pallet {
 		MaxAllowedMaxMinRatioExceeded,
 
 		/// ---- Thrown when the dispatch attempts to set weights on chain with where the normalized
-		/// max value is more than MaxClipValue.
-		MaxClipExceeded,
+		/// max value is more than MaxWeightValue.
+		MaxWeightExceeded,
 
 		/// ---- Thrown when the caller attempts to use a repeated work.
 		WorkRepeated,
@@ -1264,13 +1264,13 @@ pub mod pallet {
 		}
 
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-		pub fn sudo_set_max_clip_value ( 
+		pub fn sudo_set_max_weight_value ( 
 			origin:OriginFor<T>, 
-			max_clip_value: u32 
+			max_weight_value: u32 
 		) -> DispatchResult {
 			ensure_root( origin )?;
-			MaxClipValue::<T>::set( max_clip_value );
-			Self::deposit_event( Event::MaxClipValueSet( max_clip_value ) );
+			MaxWeightValue::<T>::set( max_weight_value );
+			Self::deposit_event( Event::MaxWeightValueSet( max_weight_value ) );
 			Ok(())
 		}
 
@@ -1532,11 +1532,11 @@ pub mod pallet {
 		pub fn set_max_allowed_max_min_ratio( max_allowed_max_min_ratio: u64 ) {
 			MaxAllowedMaxMinRatio::<T>::put( max_allowed_max_min_ratio );
 		}
-		pub fn get_max_clip_value( ) -> u32 {
-			return MaxClipValue::<T>::get();
+		pub fn get_max_weight_value( ) -> u32 {
+			return MaxWeightValue::<T>::get();
 		}
-		pub fn set_max_clip_value( max_clip_value: u32 ) {
-			MaxClipValue::<T>::put( max_clip_value );
+		pub fn set_max_weight_value( max_weight_value: u32 ) {
+			MaxWeightValue::<T>::put( max_weight_value );
 		}
 		pub fn get_immunity_period( ) -> u64 {
 			return ImmunityPeriod::<T>::get();

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -177,6 +177,19 @@ pub mod pallet {
 		/// Initial target registrations per interval.
 		#[pallet::constant]
 		type InitialTargetRegistrationsPerInterval: Get<u64>;
+
+		///// u8 where value (x) represents x * 10^-2
+		/// Initial scaling law power.
+		#[pallet::constant]
+		type InitialScalingLawPower: Get<u8>;
+
+		/// Initial synergy scaling law power.
+		#[pallet::constant]
+		type InitialSynergyScalingLawPower: Get<u8>;
+
+		/// Initial validator exclude quantile.
+		#[pallet::constant]
+		type InitialValidatorExcludeQuantile: Get<u8>;
 	}
 
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -528,6 +541,36 @@ pub mod pallet {
 		DefaultFoundationDistribution<T>
 	>;
 
+	#[pallet::type_value] 
+	pub fn DefaultScalingLawPower<T: Config>() -> u8 { T::InitialScalingLawPower::get() }
+	#[pallet::storage]
+	pub type ScalingLawPower<T> = StorageValue<
+		_, 
+		u8, 
+		ValueQuery,
+		DefaultScalingLawPower<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultSynergyScalingLawPower<T: Config>() -> u8{ T::InitialSynergyScalingLawPower::get() }
+	#[pallet::storage]
+	pub type SynergyScalingLawPower<T> = StorageValue<
+		_, 
+		u8, 
+		ValueQuery,
+		DefaultSynergyScalingLawPower<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultValidatorExcludeQuantile<T: Config>() -> u8 { T::InitialValidatorExcludeQuantile::get() }
+	#[pallet::storage]
+	pub type ValidatorExcludeQuantile<T> = StorageValue<
+		_, 
+		u8, 
+		ValueQuery,
+		DefaultValidatorExcludeQuantile<T>
+	>;
+
 	/// #[pallet::type_value] 
 	/// pub fn DefaultFoundationAccount<T: Config>() -> u64 { T::InitialFoundationAccount::get() }
 	#[pallet::storage]
@@ -743,6 +786,15 @@ pub mod pallet {
 
 		/// --- Event created when the foundation distribution has been set.
 		FoundationDistributionSet( u64 ),
+
+		/// --- Event created when the scaling law power has been set.
+		ScalingLawPowerSet( u8 ),
+
+		/// --- Event created when the synergy scaling law power has been set.
+		SynergyScalingLawPowerSet( u8 ),
+
+		/// --- Event created when the validator exclude quantile has been set.
+		ValidatorExcludeQuantileSet( u8 ),
 
 		/// --- Event created when the validator default epoch length has been set.
 		ValidatorEpochLenSet(u64),
@@ -1339,6 +1391,39 @@ pub mod pallet {
 			Self::deposit_event( Event::ResetBonds() );
 			Ok(())
 		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_scaling_law_power( 
+			origin:OriginFor<T>, 
+			scaling_law_power: u8 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+			ScalingLawPower::<T>::set( scaling_law_power );
+			Self::deposit_event( Event::ScalingLawPowerSet( scaling_law_power ));
+			Ok(())
+		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_synergy_scaling_law_power( 
+			origin:OriginFor<T>, 
+			synergy_scaling_law_power: u8 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+		    SynergyScalingLawPower::<T>::set( synergy_scaling_law_power );
+			Self::deposit_event( Event::SynergyScalingLawPowerSet( synergy_scaling_law_power ));
+			Ok(())
+		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_validator_exclude_quantile( 
+			origin:OriginFor<T>, 
+			validator_exclude_quantile: u8 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+		    ValidatorExcludeQuantile::<T>::set( validator_exclude_quantile );
+			Self::deposit_event( Event::ValidatorExcludeQuantileSet( validator_exclude_quantile ));
+			Ok(())
+		}
 	}
 
 	// ---- Subtensor helper functions.
@@ -1468,6 +1553,28 @@ pub mod pallet {
 		pub fn set_validator_epochs_per_reset( validator_epochs_per_reset: u64 ) {
 			ValidatorEpochsPerReset::<T>::put( validator_epochs_per_reset );
 		}
+
+		pub fn get_scaling_law_power( ) -> u8 {
+			return ScalingLawPower::<T>::get();
+		}
+		pub fn set_scaling_law_power( scaling_law_power: u8 ) {
+			ScalingLawPower::<T>::put( scaling_law_power );
+		}
+
+		pub fn get_synergy_scaling_law_power( ) -> u8 {
+			return SynergyScalingLawPower::<T>::get();
+		}
+		pub fn set_synergy_scaling_law_power( synergy_scaling_law_power: u8 ) {
+			SynergyScalingLawPower::<T>::put( synergy_scaling_law_power );
+		}
+
+		pub fn get_validator_exclude_quantile( ) -> u8 {
+			return ValidatorExcludeQuantile::<T>::get();
+		}
+		pub fn set_validator_exclude_quantile( validator_exclude_quantile: u8 ) {
+			ValidatorExcludeQuantile::<T>::put( validator_exclude_quantile );
+		}
+
 		// -- Get step consensus shift (1/kappa)
 		pub fn get_kappa( ) -> u64 {
 			return Kappa::<T>::get();

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -114,6 +114,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type InitialMaxAllowedMaxMinRatio: Get<u64>;
 
+		/// Initial allowed max clip value.
+		#[pallet::constant]
+		type InitialMaxClipValue: Get<u32>;
+
 		/// Initial stake pruning denominator
 		#[pallet::constant]
 		type InitialStakePruningDenominator: Get<u64>;
@@ -416,6 +420,16 @@ pub mod pallet {
 		u64, 
 		ValueQuery,
 		DefaultMaxAllowedMaxMinRatio<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultMaxClipValue<T: Config>() -> u32 { T::InitialMaxClipValue::get() }
+	#[pallet::storage]
+	pub type MaxClipValue<T> = StorageValue<
+		_, 
+		u32, 
+		ValueQuery,
+		DefaultMaxClipValue<T>
 	>;
 
 	#[pallet::type_value] 
@@ -729,6 +743,9 @@ pub mod pallet {
 		/// --- Event created when the max allowed max min ration has been set.
 		MaxAllowedMaxMinRatioSet( u64 ),
 
+		/// --- Event created when the max clip value has been set.
+		MaxClipValueSet( u32 ),
+
 		/// --- Event created when the incentive pruning denominator has been set.
 		IncentivePruningDenominatorSet( u64 ),
 
@@ -841,6 +858,10 @@ pub mod pallet {
 		/// ---- Thrown when the dispatch attempts to set weights on chain with where the normalized
 		/// max value is more than MaxAllowedMaxMinRatio.
 		MaxAllowedMaxMinRatioExceeded,
+
+		/// ---- Thrown when the dispatch attempts to set weights on chain with where the normalized
+		/// max value is more than MaxClipValue.
+		MaxClipExceeded,
 
 		/// ---- Thrown when the caller attempts to use a repeated work.
 		WorkRepeated,
@@ -1243,6 +1264,17 @@ pub mod pallet {
 		}
 
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_max_clip_value ( 
+			origin:OriginFor<T>, 
+			max_clip_value: u32 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+			MaxClipValue::<T>::set( max_clip_value );
+			Self::deposit_event( Event::MaxClipValueSet( max_clip_value ) );
+			Ok(())
+		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
 		pub fn sudo_set_validator_batch_size ( 
 			origin:OriginFor<T>, 
 			validator_batch_size: u64 
@@ -1499,6 +1531,12 @@ pub mod pallet {
 		}
 		pub fn set_max_allowed_max_min_ratio( max_allowed_max_min_ratio: u64 ) {
 			MaxAllowedMaxMinRatio::<T>::put( max_allowed_max_min_ratio );
+		}
+		pub fn get_max_clip_value( ) -> u32 {
+			return MaxClipValue::<T>::get();
+		}
+		pub fn set_max_clip_value( max_clip_value: u32 ) {
+			MaxClipValue::<T>::put( max_clip_value );
 		}
 		pub fn get_immunity_period( ) -> u64 {
 			return ImmunityPeriod::<T>::get();

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -896,6 +896,9 @@ pub mod pallet {
 
 		/// ---- Thrown when the caller attempts to use a repeated work.
 		WorkRepeated,
+
+		/// ---- Thrown when the caller attempts to set a storage value outside of its allowed range.
+		StorageValueOutOfRange,
 	}
 
 	impl<T: Config> Printable for Error<T> {
@@ -905,6 +908,7 @@ pub mod pallet {
                 Error::NotRegistered  => "The node with the supplied public key is not registered".print(),
                 Error::WeightVecNotEqualSize => "The vec of keys and the vec of values are not of the same size".print(),
                 Error::NonAssociatedColdKey => "The used cold key is not associated with the hot key acccount".print(),
+				Error::StorageValueOutOfRange => "The supplied storage value is outside of its allowed range".print(),
                 _ => "Invalid Error Case".print(),
             }
         }
@@ -1398,6 +1402,7 @@ pub mod pallet {
 			scaling_law_power: u8 
 		) -> DispatchResult {
 			ensure_root( origin )?;
+			ensure!( scaling_law_power <= 100, Error::<T>::StorageValueOutOfRange  ); // The power must be between 0 and 100 => 0% and 100%
 			ScalingLawPower::<T>::set( scaling_law_power );
 			Self::deposit_event( Event::ScalingLawPowerSet( scaling_law_power ));
 			Ok(())
@@ -1409,6 +1414,7 @@ pub mod pallet {
 			synergy_scaling_law_power: u8 
 		) -> DispatchResult {
 			ensure_root( origin )?;
+			ensure!( synergy_scaling_law_power <= 100, Error::<T>::StorageValueOutOfRange ); // The power must be between 0 and 100 => 0% and 100%
 		    SynergyScalingLawPower::<T>::set( synergy_scaling_law_power );
 			Self::deposit_event( Event::SynergyScalingLawPowerSet( synergy_scaling_law_power ));
 			Ok(())
@@ -1420,6 +1426,7 @@ pub mod pallet {
 			validator_exclude_quantile: u8 
 		) -> DispatchResult {
 			ensure_root( origin )?;
+			ensure!( validator_exclude_quantile <= 100, Error::<T>::StorageValueOutOfRange ); // The quantile must be between 0 and 100 => 0% and 100%
 		    ValidatorExcludeQuantile::<T>::set( validator_exclude_quantile );
 			Self::deposit_event( Event::ValidatorExcludeQuantileSet( validator_exclude_quantile ));
 			Ok(())

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -26,7 +26,7 @@ impl<T: Config> Pallet<T> {
         let normalized_values = normalize(values);
 
         // --- We check if the weights do not exceed the max weight limit.
-        ensure!( Self::max_weight(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded);
+        ensure!( Self::max_weight(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded );
 
         // Zip weights.
         let mut zipped_weights: Vec<(u32,u32)> = vec![];

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -25,8 +25,8 @@ impl<T: Config> Pallet<T> {
         // Normalize weights.
         let normalized_values = normalize(values);
 
-        // --- We check if the weights have an allowed max min multiple.
-        ensure!( Self::max_weight(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded );
+        // --- We check if the weights do not exceed the max weight limit.
+        ensure!( Self::max_weight(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded);
 
         // Zip weights.
         let mut zipped_weights: Vec<(u32,u32)> = vec![];
@@ -77,7 +77,7 @@ impl<T: Config> Pallet<T> {
         let min_allowed_length: usize = Self::get_min_allowed_weights() as usize;
 
         // Check self weight. Allowed to set single value for self weight.
-        if Self::is_self_weight(uid, uids, weights ) {
+        if Self::is_self_weight(uid, uids, weights) {
             return true
         }
         // Check if number of weights exceeds min.
@@ -88,15 +88,14 @@ impl<T: Config> Pallet<T> {
         return false
     }
 
-    // Checks if the any of the normalized weight magnitudes exceed the max clip.
+    // Checks if the any of the normalized weight magnitudes exceed the max weight limit.
     pub fn max_weight( uid: u32, uids: &Vec<u32>, weights: &Vec<u32>) -> bool {
 
-        // Allow self weights to exceed max clip.
-        if Self::is_self_weight(uid, uids, weights ) {
+        // Allow self weights to exceed max weight limit.
+        if Self::is_self_weight(uid, uids, weights) {
             return true
         }
 
-        // We allow the 0 value multiple to be cardinal -> We always return true.
         let max_weight_value: u32 = Self::get_max_weight_value();
         if max_weight_value == u32::MAX {
             return true;

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -88,10 +88,10 @@ impl<T: Config> Pallet<T> {
         return false
     }
 
-    // Checks if the any of the normalized weight magnitudes exceed the max clip.
+    // Checks if the any of the normalized weight magnitudes exceed the max weight.
     pub fn max_weight( uid: u32, uids: &Vec<u32>, weights: &Vec<u32>) -> bool {
 
-        // Allow self weights to exceed max clip.
+        // Allow self weights to exceed max weight.
         if Self::is_self_weight(uid, uids, weights ) {
             return true
         }

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -26,7 +26,7 @@ impl<T: Config> Pallet<T> {
         let normalized_values = normalize(values);
 
         // --- We check if the weights do not exceed the max weight limit.
-        ensure!( Self::max_weight(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded );
+        ensure!( Self::max_weight_limited(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded );
 
         // Zip weights.
         let mut zipped_weights: Vec<(u32,u32)> = vec![];
@@ -73,39 +73,39 @@ impl<T: Config> Pallet<T> {
     }
 
     // Check if weights have fewer values than are allowed.
-    pub fn check_length( uid: u32, uids: &Vec<u32>, weights: &Vec<u32>) -> bool {
+    pub fn check_length( uid: u32, uids: &Vec<u32>, weights: &Vec<u32> ) -> bool {
         let min_allowed_length: usize = Self::get_min_allowed_weights() as usize;
 
         // Check self weight. Allowed to set single value for self weight.
         if Self::is_self_weight(uid, uids, weights) {
-            return true
+            return true;
         }
         // Check if number of weights exceeds min.
         if weights.len() >= min_allowed_length {
-            return true
+            return true;
         }
         // To few weights.
-        return false
+        return false;
     }
 
     // Checks if the any of the normalized weight magnitudes exceed the max weight limit.
-    pub fn max_weight( uid: u32, uids: &Vec<u32>, weights: &Vec<u32>) -> bool {
+    pub fn max_weight_limited( uid: u32, uids: &Vec<u32>, weights: &Vec<u32> ) -> bool {
 
         // Allow self weights to exceed max weight limit.
         if Self::is_self_weight(uid, uids, weights) {
-            return true
+            return true;
         }
 
-        let max_weight_value: u32 = Self::get_max_weight_value();
-        if max_weight_value == u32::MAX {
+        let max_weight_limit: u32 = Self::get_max_weight_limit();
+        if max_weight_limit == u32::MAX {
             return true;
         }
     
         let max: u32 = *weights.iter().max().unwrap();
-        if max_weight_value <= max { 
-            return false
+        if max <= max_weight_limit { 
+            return true;
         }
-        return true;
+        return false;
     }
 
     pub fn min_is_allowed_multiple_of_max( weights: &Vec<u32>) -> bool {
@@ -118,7 +118,7 @@ impl<T: Config> Pallet<T> {
         let min: u32 = *weights.iter().min().unwrap();
         let max: u32 = *weights.iter().max().unwrap();
         if min == 0 { 
-            return false
+            return false;
         } else {
             // Check that the min is a allowed multiple of the max.
             if max / min > max_allowed_max_min_ratio {

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -88,7 +88,7 @@ impl<T: Config> Pallet<T> {
         return false;
     }
 
-    // Checks if the any of the normalized weight magnitudes exceed the max weight limit.
+    // Checks if none of the normalized weight magnitudes exceed the max weight limit.
     pub fn max_weight_limited( uid: u32, uids: &Vec<u32>, weights: &Vec<u32> ) -> bool {
 
         // Allow self weights to exceed max weight limit.

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -26,7 +26,7 @@ impl<T: Config> Pallet<T> {
         let normalized_values = normalize(values);
 
         // --- We check if the weights have an allowed max min multiple.
-        ensure!( Self::max_clip(neuron.uid, &uids, &normalized_values), Error::<T>::MaxClipExceeded );
+        ensure!( Self::max_weight(neuron.uid, &uids, &normalized_values), Error::<T>::MaxWeightExceeded );
 
         // Zip weights.
         let mut zipped_weights: Vec<(u32,u32)> = vec![];
@@ -89,7 +89,7 @@ impl<T: Config> Pallet<T> {
     }
 
     // Checks if the any of the normalized weight magnitudes exceed the max clip.
-    pub fn max_clip( uid: u32, uids: &Vec<u32>, weights: &Vec<u32>) -> bool {
+    pub fn max_weight( uid: u32, uids: &Vec<u32>, weights: &Vec<u32>) -> bool {
 
         // Allow self weights to exceed max clip.
         if Self::is_self_weight(uid, uids, weights ) {
@@ -97,13 +97,13 @@ impl<T: Config> Pallet<T> {
         }
 
         // We allow the 0 value multiple to be cardinal -> We always return true.
-        let max_clip_value: u32 = Self::get_max_clip_value();
-        if max_clip_value == u32::MAX {
+        let max_weight_value: u32 = Self::get_max_weight_value();
+        if max_weight_value == u32::MAX {
             return true;
         }
     
         let max: u32 = *weights.iter().max().unwrap();
-        if max_clip_value <= max { 
+        if max_weight_value <= max { 
             return false
         }
         return true;

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -197,6 +197,10 @@ impl pallet_subtensor::Config for Test {
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
+	
+	type InitialScalingLawPower = InitialScalingLawPower;
+	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 
 	type InitialImmunityPeriod = InitialImmunityPeriod;
 	type InitialMaxAllowedUids = InitialMaxAllowedUids;
@@ -216,10 +220,6 @@ impl pallet_subtensor::Config for Test {
 	type InitialAdjustmentInterval = InitialAdjustmentInterval;
 	type InitialMaxRegistrationsPerBlock = InitialMaxRegistrationsPerBlock;
 	type InitialTargetRegistrationsPerInterval = InitialTargetRegistrationsPerInterval;
-
-	type InitialScalingLawPower = InitialScalingLawPower;
-	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
-	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 
 }
 

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -97,7 +97,7 @@ parameter_types! {
 
 	pub const InitialMinAllowedWeights: u64 = 0;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 0;
-	pub const InitialMaxClipValue: u32 = u32::MAX;
+	pub const InitialMaxWeightValue: u32 = u32::MAX;
 	pub const InitialBlocksPerStep: u64 = 1;
 	pub const InitialIssuance: u64 = 548833985028256;
 	pub const InitialDifficulty: u64 = 10000;
@@ -200,7 +200,7 @@ impl pallet_subtensor::Config for Test {
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
-	type InitialMaxClipValue = InitialMaxClipValue;
+	type InitialMaxWeightValue = InitialMaxWeightValue;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
 	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -87,7 +87,7 @@ parameter_types! {
 	pub const InitialBondsMovingAverage: u64 = 500_000;
 	pub const InitialIncentivePruningDenominator: u64 = 1;
 	pub const InitialStakePruningDenominator: u64 = 1;
-	pub const InitialStakePruningMin: u64 = 0;
+	pub const InitialStakePruningMin: u64 = 1024;
 	pub const InitialFoundationDistribution: u64 = 0;
 
 	pub const InitialValidatorBatchSize: u64 = 10;

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -106,6 +106,10 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
+
+	pub const InitialScalingLawPower: u8 = 50;
+	pub const InitialSynergyScalingLawPower: u8 = 60;
+	pub const InitialValidatorExcludeQuantile: u8 = 10;
 }
 
 thread_local!{
@@ -212,6 +216,11 @@ impl pallet_subtensor::Config for Test {
 	type InitialAdjustmentInterval = InitialAdjustmentInterval;
 	type InitialMaxRegistrationsPerBlock = InitialMaxRegistrationsPerBlock;
 	type InitialTargetRegistrationsPerInterval = InitialTargetRegistrationsPerInterval;
+
+	type InitialScalingLawPower = InitialScalingLawPower;
+	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
+
 }
 
 impl pallet_sudo::Config for Test {

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -97,6 +97,7 @@ parameter_types! {
 
 	pub const InitialMinAllowedWeights: u64 = 0;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 0;
+	pub const InitialMaxClipValue: u32 = u32::MAX;
 	pub const InitialBlocksPerStep: u64 = 1;
 	pub const InitialIssuance: u64 = 548833985028256;
 	pub const InitialDifficulty: u64 = 10000;
@@ -199,6 +200,7 @@ impl pallet_subtensor::Config for Test {
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
+	type InitialMaxClipValue = InitialMaxClipValue;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
 	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -97,7 +97,7 @@ parameter_types! {
 
 	pub const InitialMinAllowedWeights: u64 = 0;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 0;
-	pub const InitialMaxWeightValue: u32 = u32::MAX;
+	pub const InitialMaxWeightLimit: u32 = u32::MAX;
 	pub const InitialBlocksPerStep: u64 = 1;
 	pub const InitialIssuance: u64 = 548833985028256;
 	pub const InitialDifficulty: u64 = 10000;
@@ -200,7 +200,7 @@ impl pallet_subtensor::Config for Test {
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
-	type InitialMaxWeightValue = InitialMaxWeightValue;
+	type InitialMaxWeightLimit = InitialMaxWeightLimit;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
 	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -162,6 +162,15 @@ fn test_sudo_stake_pruning_min() {
     });
 }
 
+#[test]
+fn test_sudo_max_clip_value() {
+	new_test_ext().execute_with(|| {
+        let max_clip_value: u32 = 10;
+		assert_ok!(Subtensor::sudo_set_max_clip_value(<<Test as Config>::Origin>::root(), max_clip_value));
+        assert_eq!(Subtensor::get_max_clip_value(), max_clip_value);
+    });
+}
+
 
 #[test]
 fn test_sudo_max_allowed_uids() {
@@ -381,6 +390,16 @@ fn test_fails_sudo_set_stake_pruning_min() {
         let init_stake_pruning_min: u64 = Subtensor::get_stake_pruning_min();
 		assert_eq!(Subtensor::sudo_set_stake_pruning_min(<<Test as Config>::Origin>::signed(0), stake_pruning_min),  Err(DispatchError::BadOrigin.into()));
         assert_eq!(Subtensor::get_stake_pruning_min(), init_stake_pruning_min);
+    });
+}
+
+#[test]
+fn test_fails_sudo_max_clip_value() {
+	new_test_ext().execute_with(|| {
+        let max_clip_value: u32 = 10;
+        let init_max_clip_value: u32 = Subtensor::get_max_clip_value();
+		assert_eq!(Subtensor::sudo_set_max_clip_value(<<Test as Config>::Origin>::signed(0), max_clip_value),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_max_clip_value(), init_max_clip_value);
     });
 }
 

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -163,11 +163,11 @@ fn test_sudo_stake_pruning_min() {
 }
 
 #[test]
-fn test_sudo_max_weight_value() {
+fn test_sudo_max_weight_limit() {
 	new_test_ext().execute_with(|| {
-        let max_weight_value: u32 = 10;
-		assert_ok!(Subtensor::sudo_set_max_weight_value(<<Test as Config>::Origin>::root(), max_weight_value));
-        assert_eq!(Subtensor::get_max_weight_value(), max_weight_value);
+        let max_weight_limit: u32 = 10;
+		assert_ok!(Subtensor::sudo_set_max_weight_limit(<<Test as Config>::Origin>::root(), max_weight_limit));
+        assert_eq!(Subtensor::get_max_weight_limit(), max_weight_limit);
     });
 }
 
@@ -394,12 +394,12 @@ fn test_fails_sudo_set_stake_pruning_min() {
 }
 
 #[test]
-fn test_fails_sudo_max_weight_value() {
+fn test_fails_sudo_max_weight_limit() {
 	new_test_ext().execute_with(|| {
-        let max_weight_value: u32 = 10;
-        let init_max_weight_value: u32 = Subtensor::get_max_weight_value();
-		assert_eq!(Subtensor::sudo_set_max_weight_value(<<Test as Config>::Origin>::signed(0), max_weight_value),  Err(DispatchError::BadOrigin.into()));
-        assert_eq!(Subtensor::get_max_weight_value(), init_max_weight_value);
+        let max_weight_limit: u32 = 10;
+        let init_max_weight_limit: u32 = Subtensor::get_max_weight_limit();
+		assert_eq!(Subtensor::sudo_set_max_weight_limit(<<Test as Config>::Origin>::signed(0), max_weight_limit),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_max_weight_limit(), init_max_weight_limit);
     });
 }
 

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -238,6 +238,25 @@ fn test_sudo_scaling_law_power() {
     });
 }
 
+#[test]
+fn test_sudo_synergy_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let synergy_scaling_law_power: u8 = 10;
+		assert_ok!(Subtensor::sudo_set_synergy_scaling_law_power(<<Test as Config>::Origin>::root(), synergy_scaling_law_power));
+        assert_eq!(Subtensor::get_synergy_scaling_law_power(), synergy_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_sudo_validator_exclude_quantile() {
+	new_test_ext().execute_with(|| {
+        let validator_exclude_quantile: u8 = 10;
+		assert_ok!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::root(), validator_exclude_quantile));
+        assert_eq!(Subtensor::get_validator_exclude_quantile(), validator_exclude_quantile);
+    });
+}
+
+
 //#########################
 //## sudo failure tests ###
 //#########################

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -230,6 +230,19 @@ fn test_sudo_reset_bonds() {
 }
 
 #[test]
+fn test_sudo_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let scaling_law_power: u8 = 10;
+		assert_ok!(Subtensor::sudo_set_scaling_law_power(<<Test as Config>::Origin>::root(), scaling_law_power));
+        assert_eq!(Subtensor::get_scaling_law_power(), scaling_law_power);
+    });
+}
+
+//#########################
+//## sudo failure tests ###
+//#########################
+
+#[test]
 fn test_fails_sudo_immunity_period () {
 	new_test_ext().execute_with(|| {
         let immunity_period: u64 = 10;
@@ -410,5 +423,35 @@ fn test_fails_sudo_set_validator_epochs_per_reset() {
 fn test_fails_sudo_reset_bonds() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Subtensor::sudo_reset_bonds(<<Test as Config>::Origin>::signed(0)),  Err(DispatchError::BadOrigin.into()));
+    });
+}
+
+#[test]
+fn test_fails_sudo_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let scaling_law_power: u8 = 10;
+        let init_scaling_law_power: u8 = Subtensor::get_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_scaling_law_power(<<Test as Config>::Origin>::signed(0), scaling_law_power),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_scaling_law_power(), init_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_synergy_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let synergy_scaling_law_power: u8 = 10;
+        let init_synergy_scaling_law_power: u8 = Subtensor::get_synergy_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_synergy_scaling_law_power(<<Test as Config>::Origin>::signed(0), synergy_scaling_law_power),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_synergy_scaling_law_power(), init_synergy_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_validator_exclude_quantile() {
+	new_test_ext().execute_with(|| {
+        let validator_exclude_quantile: u8 = 10;
+        let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
+		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::signed(0), validator_exclude_quantile),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
     });
 }

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -163,11 +163,11 @@ fn test_sudo_stake_pruning_min() {
 }
 
 #[test]
-fn test_sudo_max_clip_value() {
+fn test_sudo_max_weight_value() {
 	new_test_ext().execute_with(|| {
-        let max_clip_value: u32 = 10;
-		assert_ok!(Subtensor::sudo_set_max_clip_value(<<Test as Config>::Origin>::root(), max_clip_value));
-        assert_eq!(Subtensor::get_max_clip_value(), max_clip_value);
+        let max_weight_value: u32 = 10;
+		assert_ok!(Subtensor::sudo_set_max_weight_value(<<Test as Config>::Origin>::root(), max_weight_value));
+        assert_eq!(Subtensor::get_max_weight_value(), max_weight_value);
     });
 }
 
@@ -394,12 +394,12 @@ fn test_fails_sudo_set_stake_pruning_min() {
 }
 
 #[test]
-fn test_fails_sudo_max_clip_value() {
+fn test_fails_sudo_max_weight_value() {
 	new_test_ext().execute_with(|| {
-        let max_clip_value: u32 = 10;
-        let init_max_clip_value: u32 = Subtensor::get_max_clip_value();
-		assert_eq!(Subtensor::sudo_set_max_clip_value(<<Test as Config>::Origin>::signed(0), max_clip_value),  Err(DispatchError::BadOrigin.into()));
-        assert_eq!(Subtensor::get_max_clip_value(), init_max_clip_value);
+        let max_weight_value: u32 = 10;
+        let init_max_weight_value: u32 = Subtensor::get_max_weight_value();
+		assert_eq!(Subtensor::sudo_set_max_weight_value(<<Test as Config>::Origin>::signed(0), max_weight_value),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_max_weight_value(), init_max_weight_value);
     });
 }
 

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -1,5 +1,4 @@
-
-   
+use pallet_subtensor::{Error};
 use frame_support::{assert_ok};
 use frame_system::Config;
 mod mock;
@@ -471,6 +470,41 @@ fn test_fails_sudo_validator_exclude_quantile() {
         let validator_exclude_quantile: u8 = 10;
         let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
 		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::signed(0), validator_exclude_quantile),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
+    });
+}
+
+
+//##########################################
+//## sudo set with root; failure due to out of range ##
+//##########################################
+
+#[test]
+fn test_fails_sudo_scaling_law_power_out_of_range() {
+	new_test_ext().execute_with(|| {
+        let scaling_law_power: u8 = 101; // max is 100. Should fail
+        let init_scaling_law_power: u8 = Subtensor::get_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_scaling_law_power(<<Test as Config>::Origin>::root(), scaling_law_power),  Err(Error::<Test>::StorageValueOutOfRange.into()));
+        assert_eq!(Subtensor::get_scaling_law_power(), init_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_synergy_scaling_law_power_out_of_range() {
+	new_test_ext().execute_with(|| {
+        let synergy_scaling_law_power: u8 = 101; // max is 100. Should fail
+        let init_synergy_scaling_law_power: u8 = Subtensor::get_synergy_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_synergy_scaling_law_power(<<Test as Config>::Origin>::root(), synergy_scaling_law_power),  Err(Error::<Test>::StorageValueOutOfRange.into()));
+        assert_eq!(Subtensor::get_synergy_scaling_law_power(), init_synergy_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_validator_exclude_quantile_out_of_range() {
+	new_test_ext().execute_with(|| {
+        let validator_exclude_quantile: u8 = 101; // max is 100. Should fail
+        let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
+		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::root(), validator_exclude_quantile),  Err(Error::<Test>::StorageValueOutOfRange.into()));
         assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
     });
 }

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -143,7 +143,7 @@ fn test_weights_err_max_weight_limit() {
 
 		// Self weight is a success.
 		let weights_keys: Vec<u32> = vec![0]; 
-		let weight_values: Vec<u32> = vec![1]; // normalizes to u32::MAX/2
+		let weight_values: Vec<u32> = vec![1]; // normalizes to u32::MAX
 		assert_ok!(Subtensor::set_weights(Origin::signed(0), weights_keys, weight_values));
 	});
 }

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -133,11 +133,11 @@ fn test_weights_err_max_weight_value() {
 		run_to_block( 5 );
     	let _neuron = register_ok_neuron( 4, 4);
 
-		Subtensor::set_max_weight_value(u32::MAX/5); // Set max to u32::MAX/2
+		Subtensor::set_max_weight_value(u32::MAX/5); // Set max to u32::MAX/5
 
 		// Non self weight fails.
 		let weights_keys: Vec<u32> = vec![1, 2, 3, 4]; 
-		let weight_values: Vec<u32> = vec![1, 1, 1, 1]; // normalizes to u32::MAX/2
+		let weight_values: Vec<u32> = vec![1, 1, 1, 1]; // normalizes to u32::MAX/4
 		let result = Subtensor::set_weights(Origin::signed(0), weights_keys, weight_values);
 		assert_eq!(result, Err(Error::<Test>::MaxWeightExceeded.into()));
 

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -121,6 +121,34 @@ fn test_weights_err_has_duplicate_ids() {
 }
 
 #[test]
+fn test_weights_err_max_clip_value() {
+	new_test_ext().execute_with(|| {
+		let _neuron = register_ok_neuron( 0, 0);
+		run_to_block( 2 );
+    	let _neuron = register_ok_neuron( 1, 1);
+		run_to_block( 3 );
+		let _neuron = register_ok_neuron( 2, 2);
+		run_to_block( 4 );
+    	let _neuron = register_ok_neuron( 3, 3);
+		run_to_block( 5 );
+    	let _neuron = register_ok_neuron( 4, 4);
+
+		Subtensor::set_max_clip_value(u32::MAX/5); // Set max to u32::MAX/2
+
+		// Non self weight fails.
+		let weights_keys: Vec<u32> = vec![1, 2, 3, 4]; 
+		let weight_values: Vec<u32> = vec![1, 1, 1, 1]; // normalizes to u32::MAX/2
+		let result = Subtensor::set_weights(Origin::signed(0), weights_keys, weight_values);
+		assert_eq!(result, Err(Error::<Test>::MaxClipExceeded.into()));
+
+		// Self weight is a success.
+		let weights_keys: Vec<u32> = vec![0]; 
+		let weight_values: Vec<u32> = vec![1]; // normalizes to u32::MAX/2
+		assert_ok!(Subtensor::set_weights(Origin::signed(0), weights_keys, weight_values));
+	});
+}
+
+#[test]
 fn test_no_signature() {
 	new_test_ext().execute_with(|| {
 		let weights_keys: Vec<u32> = vec![];
@@ -182,39 +210,6 @@ fn test_set_weight_not_enough_values() {
 		let weight_values : Vec<u32> = vec![10, 10]; // random value.
 		Subtensor::set_min_allowed_weights(1);
 		assert_ok!( Subtensor::set_weights(Origin::signed(1), weight_keys, weight_values)) ;
-	});
-}
-
-#[test]
-fn test_set_weight_max_min_ratio_to_high() {
-	new_test_ext().execute_with(|| {
-
-        let _neuron = register_ok_neuron(1, 11);
-		let _neuron = register_ok_neuron(2, 22);
-
-		// max allowed ratio is ok.
-		let weight_keys : Vec<u32> = vec![0, 1];
-		let weight_values : Vec<u32> = vec![10, 40];		
-		assert_ok!( Subtensor::set_weights(Origin::signed(1), weight_keys, weight_values)) ;
-		
-		// Ratio is to high.
-		let weight_keys : Vec<u32> = vec![0, 1];
-		let weight_values : Vec<u32> = vec![10, 40];		
-		Subtensor::set_max_allowed_max_min_ratio(2);
-		let result = Subtensor::set_weights(Origin::signed(1), weight_keys, weight_values);
-		assert_eq!(result, Err(Error::<Test>::MaxAllowedMaxMinRatioExceeded.into()));
-
-		// Meet ratio.
-		let weight_keys : Vec<u32> = vec![0, 1];
-		let weight_values : Vec<u32> = vec![10, 20];		
-		assert_ok!( Subtensor::set_weights(Origin::signed(1), weight_keys, weight_values)) ;
-
-		// Ratio limit is lowered
-		let weight_keys : Vec<u32> = vec![0, 1];
-		let weight_values : Vec<u32> = vec![10, 40];		
-		Subtensor::set_max_allowed_max_min_ratio(4);
-		assert_ok!( Subtensor::set_weights(Origin::signed(1), weight_keys, weight_values) );
-
 	});
 }
 

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -121,7 +121,7 @@ fn test_weights_err_has_duplicate_ids() {
 }
 
 #[test]
-fn test_weights_err_max_clip_value() {
+fn test_weights_err_max_weight_value() {
 	new_test_ext().execute_with(|| {
 		let _neuron = register_ok_neuron( 0, 0);
 		run_to_block( 2 );
@@ -133,13 +133,13 @@ fn test_weights_err_max_clip_value() {
 		run_to_block( 5 );
     	let _neuron = register_ok_neuron( 4, 4);
 
-		Subtensor::set_max_clip_value(u32::MAX/5); // Set max to u32::MAX/2
+		Subtensor::set_max_weight_value(u32::MAX/5); // Set max to u32::MAX/2
 
 		// Non self weight fails.
 		let weights_keys: Vec<u32> = vec![1, 2, 3, 4]; 
 		let weight_values: Vec<u32> = vec![1, 1, 1, 1]; // normalizes to u32::MAX/2
 		let result = Subtensor::set_weights(Origin::signed(0), weights_keys, weight_values);
-		assert_eq!(result, Err(Error::<Test>::MaxClipExceeded.into()));
+		assert_eq!(result, Err(Error::<Test>::MaxWeightExceeded.into()));
 
 		// Self weight is a success.
 		let weights_keys: Vec<u32> = vec![0]; 

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -121,7 +121,7 @@ fn test_weights_err_has_duplicate_ids() {
 }
 
 #[test]
-fn test_weights_err_max_weight_value() {
+fn test_weights_err_max_weight_limit() {
 	new_test_ext().execute_with(|| {
 		let _neuron = register_ok_neuron( 0, 0);
 		run_to_block( 2 );
@@ -133,7 +133,7 @@ fn test_weights_err_max_weight_value() {
 		run_to_block( 5 );
     	let _neuron = register_ok_neuron( 4, 4);
 
-		Subtensor::set_max_weight_value(u32::MAX/5); // Set max to u32::MAX/2
+		Subtensor::set_max_weight_limit(u32::MAX/5); // Set max to u32::MAX/2
 
 		// Non self weight fails.
 		let weights_keys: Vec<u32> = vec![1, 2, 3, 4]; 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,6 +293,10 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
+	// u8 where value represents x * 10^-2
+	pub const InitialScalingLawPower: u8 = 50; // 0.5
+	pub const InitialSynergyScalingLawPower: u8 = 60; // 0.6
+	pub const InitialValidatorExcludeQuantile: u8 = 10; // 0.1
 }
 
 /// Configure the pallet-template in pallets/template.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 109,
+	spec_version: 110,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -275,6 +275,12 @@ parameter_types! {
 	pub const InitialValidatorSequenceLen: u64 = 10;
 	pub const InitialValidatorEpochLen: u64 = 1000;
 	pub const InitialValidatorEpochsPerReset: u64 = 10;
+	
+	// u8 where value (x) represents x * 10^-2
+	pub const InitialScalingLawPower: u8 = 50; // 0.5
+	pub const InitialSynergyScalingLawPower: u8 = 60; // 0.6
+	pub const InitialValidatorExcludeQuantile: u8 = 10; // 0.1
+
 	pub const InitialImmunityPeriod: u64 = 200;
 	pub const InitialBlocksPerStep: u64 = 100;
 	pub const InitialMaxAllowedUids: u64 = 2000;
@@ -293,10 +299,6 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
-	// u8 where value represents x * 10^-2
-	pub const InitialScalingLawPower: u8 = 50; // 0.5
-	pub const InitialSynergyScalingLawPower: u8 = 60; // 0.6
-	pub const InitialValidatorExcludeQuantile: u8 = 10; // 0.1
 }
 
 /// Configure the pallet-template in pallets/template.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 110,
+	spec_version: 111,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -280,7 +280,7 @@ parameter_types! {
 	pub const InitialMaxAllowedUids: u64 = 2000;
 	pub const InitialMinAllowedWeights: u64 = 1;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 10;
-	pub const InitialMaxWeightValue: u32 = u32::MAX;
+	pub const InitialMaxWeightLimit: u32 = u32::MAX;
 	pub const InitialIssuance: u64 = 548833985028256;
 	pub const InitialBondsMovingAverage: u64 = 900_000;
 	pub const InitialIncentivePruningDenominator: u64 = 1;
@@ -314,7 +314,7 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
-	type InitialMaxWeightValue = InitialMaxWeightValue;
+	type InitialMaxWeightLimit = InitialMaxWeightLimit;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
 	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -311,6 +311,9 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialRho = InitialRho;
 	type InitialKappa = InitialKappa;
 	type SelfOwnership = SelfOwnership;
+	type InitialScalingLawPower = InitialScalingLawPower;
+	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 	type InitialValidatorBatchSize = InitialValidatorBatchSize;
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 109,
+	spec_version: 110,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -280,6 +280,7 @@ parameter_types! {
 	pub const InitialMaxAllowedUids: u64 = 2000;
 	pub const InitialMinAllowedWeights: u64 = 1;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 10;
+	pub const InitialMaxClipValue: u32 = u32::MAX;
 	pub const InitialIssuance: u64 = 548833985028256;
 	pub const InitialBondsMovingAverage: u64 = 900_000;
 	pub const InitialIncentivePruningDenominator: u64 = 1;
@@ -313,6 +314,7 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
+	type InitialMaxClipValue = InitialMaxClipValue;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
 	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -280,7 +280,7 @@ parameter_types! {
 	pub const InitialMaxAllowedUids: u64 = 2000;
 	pub const InitialMinAllowedWeights: u64 = 1;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 10;
-	pub const InitialMaxClipValue: u32 = u32::MAX;
+	pub const InitialMaxWeightValue: u32 = u32::MAX;
 	pub const InitialIssuance: u64 = 548833985028256;
 	pub const InitialBondsMovingAverage: u64 = 900_000;
 	pub const InitialIncentivePruningDenominator: u64 = 1;
@@ -314,7 +314,7 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;
 	type InitialBondsMovingAverage = InitialBondsMovingAverage;
 	type InitialMaxAllowedMaxMinRatio = InitialMaxAllowedMaxMinRatio;
-	type InitialMaxClipValue = InitialMaxClipValue;
+	type InitialMaxWeightValue = InitialMaxWeightValue;
 	type InitialStakePruningDenominator = InitialStakePruningDenominator;
 	type InitialStakePruningMin = InitialStakePruningMin;
 	type InitialIncentivePruningDenominator = InitialIncentivePruningDenominator;

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -18,6 +18,6 @@
 | **validatorEpochLen**              | 250                  |
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 64                   |
-| **maxClipValue**                   | 4_294_967_295        |
+| **MaxWeightLimit**                 | 4_294_967_295        |
 
 

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -1,21 +1,23 @@
-| **Validator Hyperparameter**       | **Value** |
-|------------------------------------|-----------|
-| **activityCutoff**                 | 5000      |
-| **adjustmentInterval**             | 100       |
-| **blocksPerStep**                  | 100       |
-| **bondsMovingAverage**             | 900,000   |
-| **immunityPeriod**                 | 2048      |
-| **incentivePruningDenominator**    | 1         |
-| **kappa**                          | 2         |
-| **maxAllowedMaxMinRatio**          | 64        |
-| **maxAllowedUids**                 | 4096      |
-| **minAllowedWeights**              | 1024      |
-| **rho**                            | 10        |
-| **stakePruningDenominator**        | 20        |
-| **stakePruningMin**                | 1024      |
-| **targetRegistrationsPerInterval** | 2         |
-| **validatorBatchSize**             | 32        |
-| **validatorEpochLen**              | 250       |
-| **validatorEpochsPerReset**        | 60        |
-| **validatorSequenceLength**        | 64        |
+| **Validator Hyperparameter**       | **Value**            |
+|------------------------------------|----------------------|
+| **activityCutoff**                 | 5000                 |
+| **adjustmentInterval**             | 100                  |
+| **blocksPerStep**                  | 100                  |
+| **bondsMovingAverage**             | 900,000              |
+| **immunityPeriod**                 | 2048                 |
+| **incentivePruningDenominator**    | 1                    |
+| **kappa**                          | 2                    |
+| **maxAllowedMaxMinRatio**          | 64                   |
+| **maxAllowedUids**                 | 4096                 |
+| **minAllowedWeights**              | 1024                 |
+| **rho**                            | 10                   |
+| **stakePruningDenominator**        | 20                   |
+| **stakePruningMin**                | 1024                 |
+| **targetRegistrationsPerInterval** | 2                    |
+| **validatorBatchSize**             | 32                   |
+| **validatorEpochLen**              | 250                  |
+| **validatorEpochsPerReset**        | 60                   |
+| **validatorSequenceLength**        | 64                   |
+| **maxClipValue**                   | 4_294_967_295        |
+
 

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -18,6 +18,6 @@
 | **validatorEpochLen**              | 250                  |
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 64                   |
-| **maxClipValue**                   | 4_294_967_295        |
+| **maxWeightValue**                   | 4_294_967_295        |
 
 

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -18,4 +18,7 @@
 | **validatorEpochLen**              | 250                  |
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 128                  |
+| **validatorExcludeQuantile**       | 10                   |
+| **scalingLawPower**                | 50                   |
+| **synergyScalingLawPower**         | 60                   |
 | **MaxWeightLimit**                 | 4_294_967_295        |


### PR DESCRIPTION
This PR replaces the max allowed min-max ratio computation in exchange for a max clip check. 
The max clip value checks that the normalized weights do not exceed the max clip value.

A new hyper-parameter MaxClipValue has been added with an initial value equal to u32:MAX = 4,294,967,295
At this initial value, there is no restriction on the u32 weights set by a validator.


Merge With Vunes PR:

This PR adds 3 new hyperparameters as sudo-protected constants to the subtensor pallet.

ScalingLawPower: u8 = 50
SynergyScalingLawPower: u8 = 60
ValidatorExcludeQuantile: u8 = 10
Each value is stored as an unsigned 8-bit integer
Each value x here represents the value x * 10^-2
Meaning each can store floats between [0.0, 1.0] with a precision of 0.01

