### PR TITLE
[Feature] add synapse hyperparams

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -177,6 +177,19 @@ pub mod pallet {
 		/// Initial target registrations per interval.
 		#[pallet::constant]
 		type InitialTargetRegistrationsPerInterval: Get<u64>;
+
+		///// u8 where value (x) represents x * 10^-2
+		/// Initial scaling law power.
+		#[pallet::constant]
+		type InitialScalingLawPower: Get<u8>;
+
+		/// Initial synergy scaling law power.
+		#[pallet::constant]
+		type InitialSynergyScalingLawPower: Get<u8>;
+
+		/// Initial validator exclude quantile.
+		#[pallet::constant]
+		type InitialValidatorExcludeQuantile: Get<u8>;
 	}
 
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -528,6 +541,36 @@ pub mod pallet {
 		DefaultFoundationDistribution<T>
 	>;
 
+	#[pallet::type_value] 
+	pub fn DefaultScalingLawPower<T: Config>() -> u8 { T::InitialScalingLawPower::get() }
+	#[pallet::storage]
+	pub type ScalingLawPower<T> = StorageValue<
+		_, 
+		u8, 
+		ValueQuery,
+		DefaultScalingLawPower<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultSynergyScalingLawPower<T: Config>() -> u8{ T::InitialSynergyScalingLawPower::get() }
+	#[pallet::storage]
+	pub type SynergyScalingLawPower<T> = StorageValue<
+		_, 
+		u8, 
+		ValueQuery,
+		DefaultSynergyScalingLawPower<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultValidatorExcludeQuantile<T: Config>() -> u8 { T::InitialValidatorExcludeQuantile::get() }
+	#[pallet::storage]
+	pub type ValidatorExcludeQuantile<T> = StorageValue<
+		_, 
+		u8, 
+		ValueQuery,
+		DefaultValidatorExcludeQuantile<T>
+	>;
+
 	/// #[pallet::type_value] 
 	/// pub fn DefaultFoundationAccount<T: Config>() -> u64 { T::InitialFoundationAccount::get() }
 	#[pallet::storage]
@@ -743,6 +786,15 @@ pub mod pallet {
 
 		/// --- Event created when the foundation distribution has been set.
 		FoundationDistributionSet( u64 ),
+
+		/// --- Event created when the scaling law power has been set.
+		ScalingLawPowerSet( u8 ),
+
+		/// --- Event created when the synergy scaling law power has been set.
+		SynergyScalingLawPowerSet( u8 ),
+
+		/// --- Event created when the validator exclude quantile has been set.
+		ValidatorExcludeQuantileSet( u8 ),
 
 		/// --- Event created when the validator default epoch length has been set.
 		ValidatorEpochLenSet(u64),
@@ -1339,6 +1391,39 @@ pub mod pallet {
 			Self::deposit_event( Event::ResetBonds() );
 			Ok(())
 		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_scaling_law_power( 
+			origin:OriginFor<T>, 
+			scaling_law_power: u8 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+			ScalingLawPower::<T>::set( scaling_law_power );
+			Self::deposit_event( Event::ScalingLawPowerSet( scaling_law_power ));
+			Ok(())
+		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_synergy_scaling_law_power( 
+			origin:OriginFor<T>, 
+			synergy_scaling_law_power: u8 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+		    SynergyScalingLawPower::<T>::set( synergy_scaling_law_power );
+			Self::deposit_event( Event::SynergyScalingLawPowerSet( synergy_scaling_law_power ));
+			Ok(())
+		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_validator_exclude_quantile( 
+			origin:OriginFor<T>, 
+			validator_exclude_quantile: u8 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+		    ValidatorExcludeQuantile::<T>::set( validator_exclude_quantile );
+			Self::deposit_event( Event::ValidatorExcludeQuantileSet( validator_exclude_quantile ));
+			Ok(())
+		}
 	}
 
 	// ---- Subtensor helper functions.
@@ -1468,6 +1553,28 @@ pub mod pallet {
 		pub fn set_validator_epochs_per_reset( validator_epochs_per_reset: u64 ) {
 			ValidatorEpochsPerReset::<T>::put( validator_epochs_per_reset );
 		}
+
+		pub fn get_scaling_law_power( ) -> u8 {
+			return ScalingLawPower::<T>::get();
+		}
+		pub fn set_scaling_law_power( scaling_law_power: u8 ) {
+			ScalingLawPower::<T>::put( scaling_law_power );
+		}
+
+		pub fn get_synergy_scaling_law_power( ) -> u8 {
+			return SynergyScalingLawPower::<T>::get();
+		}
+		pub fn set_synergy_scaling_law_power( synergy_scaling_law_power: u8 ) {
+			SynergyScalingLawPower::<T>::put( synergy_scaling_law_power );
+		}
+
+		pub fn get_validator_exclude_quantile( ) -> u8 {
+			return ValidatorExcludeQuantile::<T>::get();
+		}
+		pub fn set_validator_exclude_quantile( validator_exclude_quantile: u8 ) {
+			ValidatorExcludeQuantile::<T>::put( validator_exclude_quantile );
+		}
+
 		// -- Get step consensus shift (1/kappa)
 		pub fn get_kappa( ) -> u64 {
 			return Kappa::<T>::get();

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -896,6 +896,9 @@ pub mod pallet {
 
 		/// ---- Thrown when the caller attempts to use a repeated work.
 		WorkRepeated,
+
+		/// ---- Thrown when the caller attempts to set a storage value outside of its allowed range.
+		StorageValueOutOfRange,
 	}
 
 	impl<T: Config> Printable for Error<T> {
@@ -905,6 +908,7 @@ pub mod pallet {
                 Error::NotRegistered  => "The node with the supplied public key is not registered".print(),
                 Error::WeightVecNotEqualSize => "The vec of keys and the vec of values are not of the same size".print(),
                 Error::NonAssociatedColdKey => "The used cold key is not associated with the hot key acccount".print(),
+				Error::StorageValueOutOfRange => "The supplied storage value is outside of its allowed range".print(),
                 _ => "Invalid Error Case".print(),
             }
         }
@@ -1398,6 +1402,7 @@ pub mod pallet {
 			scaling_law_power: u8 
 		) -> DispatchResult {
 			ensure_root( origin )?;
+			ensure!( scaling_law_power <= 100, Error::<T>::StorageValueOutOfRange  ); // The power must be between 0 and 100 => 0% and 100%
 			ScalingLawPower::<T>::set( scaling_law_power );
 			Self::deposit_event( Event::ScalingLawPowerSet( scaling_law_power ));
 			Ok(())
@@ -1409,6 +1414,7 @@ pub mod pallet {
 			synergy_scaling_law_power: u8 
 		) -> DispatchResult {
 			ensure_root( origin )?;
+			ensure!( synergy_scaling_law_power <= 100, Error::<T>::StorageValueOutOfRange ); // The power must be between 0 and 100 => 0% and 100%
 		    SynergyScalingLawPower::<T>::set( synergy_scaling_law_power );
 			Self::deposit_event( Event::SynergyScalingLawPowerSet( synergy_scaling_law_power ));
 			Ok(())
@@ -1420,6 +1426,7 @@ pub mod pallet {
 			validator_exclude_quantile: u8 
 		) -> DispatchResult {
 			ensure_root( origin )?;
+			ensure!( validator_exclude_quantile <= 100, Error::<T>::StorageValueOutOfRange ); // The quantile must be between 0 and 100 => 0% and 100%
 		    ValidatorExcludeQuantile::<T>::set( validator_exclude_quantile );
 			Self::deposit_event( Event::ValidatorExcludeQuantileSet( validator_exclude_quantile ));
 			Ok(())

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -197,6 +197,10 @@ impl pallet_subtensor::Config for Test {
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
+	
+	type InitialScalingLawPower = InitialScalingLawPower;
+	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 
 	type InitialImmunityPeriod = InitialImmunityPeriod;
 	type InitialMaxAllowedUids = InitialMaxAllowedUids;
@@ -216,10 +220,6 @@ impl pallet_subtensor::Config for Test {
 	type InitialAdjustmentInterval = InitialAdjustmentInterval;
 	type InitialMaxRegistrationsPerBlock = InitialMaxRegistrationsPerBlock;
 	type InitialTargetRegistrationsPerInterval = InitialTargetRegistrationsPerInterval;
-
-	type InitialScalingLawPower = InitialScalingLawPower;
-	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
-	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 
 }
 

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -106,6 +106,10 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
+
+	pub const InitialScalingLawPower: u8 = 50;
+	pub const InitialSynergyScalingLawPower: u8 = 60;
+	pub const InitialValidatorExcludeQuantile: u8 = 10;
 }
 
 thread_local!{
@@ -212,6 +216,11 @@ impl pallet_subtensor::Config for Test {
 	type InitialAdjustmentInterval = InitialAdjustmentInterval;
 	type InitialMaxRegistrationsPerBlock = InitialMaxRegistrationsPerBlock;
 	type InitialTargetRegistrationsPerInterval = InitialTargetRegistrationsPerInterval;
+
+	type InitialScalingLawPower = InitialScalingLawPower;
+	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
+
 }
 
 impl pallet_sudo::Config for Test {

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -238,6 +238,25 @@ fn test_sudo_scaling_law_power() {
     });
 }
 
+#[test]
+fn test_sudo_synergy_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let synergy_scaling_law_power: u8 = 10;
+		assert_ok!(Subtensor::sudo_set_synergy_scaling_law_power(<<Test as Config>::Origin>::root(), synergy_scaling_law_power));
+        assert_eq!(Subtensor::get_synergy_scaling_law_power(), synergy_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_sudo_validator_exclude_quantile() {
+	new_test_ext().execute_with(|| {
+        let validator_exclude_quantile: u8 = 10;
+		assert_ok!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::root(), validator_exclude_quantile));
+        assert_eq!(Subtensor::get_validator_exclude_quantile(), validator_exclude_quantile);
+    });
+}
+
+
 //#########################
 //## sudo failure tests ###
 //#########################

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -230,6 +230,19 @@ fn test_sudo_reset_bonds() {
 }
 
 #[test]
+fn test_sudo_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let scaling_law_power: u8 = 10;
+		assert_ok!(Subtensor::sudo_set_scaling_law_power(<<Test as Config>::Origin>::root(), scaling_law_power));
+        assert_eq!(Subtensor::get_scaling_law_power(), scaling_law_power);
+    });
+}
+
+//#########################
+//## sudo failure tests ###
+//#########################
+
+#[test]
 fn test_fails_sudo_immunity_period () {
 	new_test_ext().execute_with(|| {
         let immunity_period: u64 = 10;
@@ -410,5 +423,35 @@ fn test_fails_sudo_set_validator_epochs_per_reset() {
 fn test_fails_sudo_reset_bonds() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Subtensor::sudo_reset_bonds(<<Test as Config>::Origin>::signed(0)),  Err(DispatchError::BadOrigin.into()));
+    });
+}
+
+#[test]
+fn test_fails_sudo_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let scaling_law_power: u8 = 10;
+        let init_scaling_law_power: u8 = Subtensor::get_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_scaling_law_power(<<Test as Config>::Origin>::signed(0), scaling_law_power),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_scaling_law_power(), init_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_synergy_scaling_law_power() {
+	new_test_ext().execute_with(|| {
+        let synergy_scaling_law_power: u8 = 10;
+        let init_synergy_scaling_law_power: u8 = Subtensor::get_synergy_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_synergy_scaling_law_power(<<Test as Config>::Origin>::signed(0), synergy_scaling_law_power),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_synergy_scaling_law_power(), init_synergy_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_validator_exclude_quantile() {
+	new_test_ext().execute_with(|| {
+        let validator_exclude_quantile: u8 = 10;
+        let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
+		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::signed(0), validator_exclude_quantile),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
     });
 }

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -1,5 +1,4 @@
-
-   
+use pallet_subtensor::{Error};
 use frame_support::{assert_ok};
 use frame_system::Config;
 mod mock;
@@ -471,6 +470,41 @@ fn test_fails_sudo_validator_exclude_quantile() {
         let validator_exclude_quantile: u8 = 10;
         let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
 		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::signed(0), validator_exclude_quantile),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
+    });
+}
+
+
+//##########################################
+//## sudo set with root; failure due to out of range ##
+//##########################################
+
+#[test]
+fn test_fails_sudo_scaling_law_power_out_of_range() {
+	new_test_ext().execute_with(|| {
+        let scaling_law_power: u8 = 101; // max is 100. Should fail
+        let init_scaling_law_power: u8 = Subtensor::get_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_scaling_law_power(<<Test as Config>::Origin>::root(), scaling_law_power),  Err(Error::<Test>::StorageValueOutOfRange.into()));
+        assert_eq!(Subtensor::get_scaling_law_power(), init_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_synergy_scaling_law_power_out_of_range() {
+	new_test_ext().execute_with(|| {
+        let synergy_scaling_law_power: u8 = 101; // max is 100. Should fail
+        let init_synergy_scaling_law_power: u8 = Subtensor::get_synergy_scaling_law_power();
+		assert_eq!(Subtensor::sudo_set_synergy_scaling_law_power(<<Test as Config>::Origin>::root(), synergy_scaling_law_power),  Err(Error::<Test>::StorageValueOutOfRange.into()));
+        assert_eq!(Subtensor::get_synergy_scaling_law_power(), init_synergy_scaling_law_power);
+    });
+}
+
+#[test]
+fn test_fails_sudo_validator_exclude_quantile_out_of_range() {
+	new_test_ext().execute_with(|| {
+        let validator_exclude_quantile: u8 = 101; // max is 100. Should fail
+        let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
+		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::root(), validator_exclude_quantile),  Err(Error::<Test>::StorageValueOutOfRange.into()));
         assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,6 +293,10 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
+	// u8 where value represents x * 10^-2
+	pub const InitialScalingLawPower: u8 = 50; // 0.5
+	pub const InitialSynergyScalingLawPower: u8 = 60; // 0.6
+	pub const InitialValidatorExcludeQuantile: u8 = 10; // 0.1
 }
 
 /// Configure the pallet-template in pallets/template.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 109,
+	spec_version: 110,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -275,6 +275,12 @@ parameter_types! {
 	pub const InitialValidatorSequenceLen: u64 = 10;
 	pub const InitialValidatorEpochLen: u64 = 1000;
 	pub const InitialValidatorEpochsPerReset: u64 = 10;
+	
+	// u8 where value (x) represents x * 10^-2
+	pub const InitialScalingLawPower: u8 = 50; // 0.5
+	pub const InitialSynergyScalingLawPower: u8 = 60; // 0.6
+	pub const InitialValidatorExcludeQuantile: u8 = 10; // 0.1
+
 	pub const InitialImmunityPeriod: u64 = 200;
 	pub const InitialBlocksPerStep: u64 = 100;
 	pub const InitialMaxAllowedUids: u64 = 2000;
@@ -293,10 +299,6 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
-	// u8 where value represents x * 10^-2
-	pub const InitialScalingLawPower: u8 = 50; // 0.5
-	pub const InitialSynergyScalingLawPower: u8 = 60; // 0.6
-	pub const InitialValidatorExcludeQuantile: u8 = 10; // 0.1
 }
 
 /// Configure the pallet-template in pallets/template.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -314,6 +314,11 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
+
+	type InitialScalingLawPower = InitialScalingLawPower;
+	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
+
 	type InitialImmunityPeriod = InitialImmunityPeriod;
 	type InitialMaxAllowedUids = InitialMaxAllowedUids;
 	type InitialMinAllowedWeights = InitialMinAllowedWeights;


### PR DESCRIPTION
This PR adds 3 new hyperparameters as sudo-protected constants to the subtensor pallet.  
1. `ScalingLawPower: u8 = 50`
1. `SynergyScalingLawPower: u8 = 60`
1. `ValidatorExcludeQuantile: u8 = 10`  
Each value is stored as an unsigned 8-bit integer  
Each value `x` here represents the value `x * 10^-2`
Meaning each can store floats between `[0.0, 1.0]` with a precision of `0.01`   