### PR TITLE
Added more requirements to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   node-subtensor:
     container_name: node-subtensor
     image: opentensorfdn/subtensor:latest
-    cpu_count: 2
-    mem_limit: 4000000000
-    memswap_limit: 8000000000
+    cpu_count: 4
+    mem_limit: 10000000000
+    memswap_limit: 20000000000
     ports:
       - "9944:9944"
       - "30333:30333"


### PR DESCRIPTION
Currently docker compose memory requirements are too small for the size of our blockchain. This is causing a lot of OOMs and unstable performance. This PR doubles the requirements.