### PR TITLE
increased immunityPeriod by 25%

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -4,7 +4,7 @@
 | **adjustmentInterval**             | 100                  |
 | **blocksPerStep**                  | 100                  |
 | **bondsMovingAverage**             | 900,000              |
-| **immunityPeriod**                 | 2048                 |
+| **immunityPeriod**                 | 2560                 |
 | **incentivePruningDenominator**    | 1                    |
 | **kappa**                          | 2                    |
 | **maxAllowedMaxMinRatio**          | 64                   |


### PR DESCRIPTION
### **Increase immunityPeriod to 2560**

**Abstract**
This recommends an increase of the immunityPeriod of the newly registered hotkeys, from 2048 blocks to 2560 blocks.

**Motivation**
As the network is quickly maturing, new miners are finding difficult to increase their incentive during the current immunity period and are ending up being deregistered immediately after immunity period. 
Due to the fact that the registration difficulty increased, newly registered miners are directly competing with the ones that are trying to find the POW solution which is quite unfair.

**Value proposal**
25% increase from 2048 to 2560