### PR TITLE
Increase validatorSequenceLength to 256

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -17,7 +17,7 @@
 | **validatorBatchSize**             | 32                   |
 | **validatorEpochLen**              | 250                  |
 | **validatorEpochsPerReset**        | 60                   |
-| **validatorSequenceLength**        | 128                  |
+| **validatorSequenceLength**        | 256                  |
 | **validatorExcludeQuantile**       | 10                   |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 60                   |


### PR DESCRIPTION
### Increase validatorSequenceLength to 256 [in monitored increments of 32]

**Abstract**
This recommends a periodic increase of sequence length of validation queries, from current 128 tokens to suggested 256 tokens, in monitored increments of 32. This means it should be increased to 160, 192, 224, and then 256, with a period of monitoring the network state in between each increase, where the decision for further increases will be dependent on network health.

**Motivation**
Transformer implementations are typically designed firstly to favor speedup for larger sequence lengths, as opposed to batch size, for instance. Transformer capability is also tied to the extent of its context window (sequence length), where longer sequence support generally result in greater coherence and comprehension due to greater recall of earlier states.

As described in issue https://github.com/opentensor/subtensor/pull/7 the validatorSequenceLength parameter should be readily increased to 1024 and beyond, since model implementations and compute should naturally support longer sequence lengths in a fairly optimized manner.

The current setup favours small models due to the short sequence length, but also forces operators to use smaller models due to the high batch size. Longer sequence lengths means that bigger AI models have a better chance for doing one-shots, and since bigger AI models can handle at least 1024 tokens, this should eventually be pushed to the maximum size for the biggest models (2048).

**Specification**
Param: validatorSequenceLength
Initial Value: 128
Suggested Value: 256
Time of Effect: 21 October 2022 (projected)