### PR TITLE
add flags to increase buffer and payload sizes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,5 @@ services:
       - "9933"
     environment:
       - CARGO_HOME=/var/www/node-subtensor/.cargo
-    command: bash -c "/usr/local/bin/node-subtensor --base-path /root/.local/share/node-subtensor/ --chain /subtensor/specs/nakamotoSpecRaw.json --rpc-external --ws-external --rpc-cors all --no-mdns --ws-max-connections 10000 --in-peers 500 --out-peers 500"
+    command: bash -c "/usr/local/bin/node-subtensor --base-path /root/.local/share/node-subtensor/ --chain /subtensor/specs/nakamotoSpecRaw.json --rpc-external --ws-external --rpc-cors all --no-mdns --ws-max-connections 10000 --in-peers 500 --out-peers 500 --ws-max-out-buffer-capacity 1024 --rpc-max-payload 1000"
 


### PR DESCRIPTION
This PR adds the flags `--ws-max-out-buffer-capacity 1024 --rpc-max-payload 1000` to the subtensor node launch command. 

This is to add support for [subtensorapi](https://github.com/opentensor/subtensor-node-api) as the request to get the whole `subtensorModule.neurons` map currently fails due to the default 5MB output buffer. Increasing it to 1024(MB) will add support for this and allow one request for the entire map.  
