### PR TITLE
Add log file rotation and size restrictions to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     cpu_count: 4
     mem_limit: 10000000000
     memswap_limit: 20000000000
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
     ports:
       - "9944:9944"
       - "30333:30333"


### PR DESCRIPTION
This PR adds:
    
    logging:
      driver: "json-file"
      options:
        max-size: "10m"
        max-file: "5"

to the subtensor `docker-compose.yml` file.  
This change would add automatic log rotation to launched subtensor nodes and restrict the maximum disk usage that these log files could take-up.  

Currently, there is no such restriction and these logs can quickly exhaust a large amount of storage. 
This change should reduce the impact of logging and reduce disk storage errors.  