### PR TITLE
increase immunity length to 7200 blocks (1 day)

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -4,7 +4,7 @@
 | **adjustmentInterval**             | 100                  |
 | **blocksPerStep**                  | 100                  |
 | **bondsMovingAverage**             | 900,000              |
-| **immunityPeriod**                 | 2048                 |
+| **immunityPeriod**                 | 7200                 |
 | **incentivePruningDenominator**    | 1                    |
 | **kappa**                          | 2                    |
 | **maxAllowedMaxMinRatio**          | 64                   |


### PR DESCRIPTION
**Increase immunity length from ~6.8h to 24h**

**Abstract**
This recommends an increase of immunity length for new models on the network in order to given them a better chance at being fairly evaluated.

**Motivation**
Personal testing has revealed to me that the network isn't giving sufficient time for my models to be evaluated fairly. For instance, there are a known 300 uids on the network with < 0.00001t emissions. However even though I'm running a 6b paramater model, because the network of validators have reached consensus and they restart ~2 days, not enough of them are able to discover and sufficiently test the model for its true value. Given 24 hours, around half the validators in the network will have had a epoch reset and will then discover and value the model correctly.