### PR TITLE
Increase immunityPeriod from 2048 to 3072

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -4,7 +4,7 @@
 | **adjustmentInterval**             | 100                  |
 | **blocksPerStep**                  | 100                  |
 | **bondsMovingAverage**             | 900,000              |
-| **immunityPeriod**                 | 2048                 |
+| **immunityPeriod**                 | 3072                 |
 | **incentivePruningDenominator**    | 1                    |
 | **kappa**                          | 2                    |
 | **maxAllowedMaxMinRatio**          | 64                   |


### PR DESCRIPTION
### Increase immunityPeriod to 3072

**Abstract**
This recommends an increase of `immunityPeriod` from 2048 blocks to 3072 blocks.

**Motivation**
Newly registered keys running above average models are experiencing an increasing failure rate in staying registered, due to a combination of factors like the validator exponential moving average requiring longer time to saturate to full server scores. A 50% increase in the `immunityPeriod` should provide more time for new servers to be more fully evaluated in the network and reach their true scores.

The current `immunityPeriod` is 2048 blocks x 12 secs / 60 sec / 60 mins = 6,8 hours, and the suggested change is to 3072 blocks x 12 secs / 60 sec / 60 mins = 10,2 hours which is 50% longer.

We should monitor attrition rates and confirm that there are no unintended consequences from longer immunity, including key squatting where registration is not followed with bona fide incentive building or proper validation. Further `immunityPeriod` increases or other interventions may follow to complement this.

**Specification**
Param: immunityPeriod
Initial Value: 2048
Suggested Value: 3072
Time of Effect: 8 November 2022 (projected)