### PR TITLE
Set MaxWeightValue to 17,179,868 == 0.004

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -20,4 +20,4 @@
 | **validatorExcludeQuantile**       | 10                   |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 60                   |
-| **MaxWeightLimit**                 | 8_589_934            |
+| **MaxWeightLimit**                 | 17_179_868           |

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -20,4 +20,4 @@
 | **validatorExcludeQuantile**       | 10                   |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 60                   |
-| **MaxWeightLimit**                 | 4_294_967_295        |
+| **MaxWeightLimit**                 | 8_589_934            |


### PR DESCRIPTION
# Decrease MaxWeightValue to 17,179,868

## Abstract
This recommends a decrease of MaxWeightValue from 4,294,967,295 to 17,179,868
## Motivation
The current value of 4294967295 (max uint32) allows validators to set arbitrary valued weights. 
The proposed value of 17,179,868 is the largest value seen across weights. You can check this as follows:

g = bittensor.metagraph().sync()
validators = g.uids[ ((g.W != 0).sum(1) != 1) ]
print ( g.W[validators].max() )

The largest value seen (note, there is also a testing value of 0.1 on chain ) is 0.0040. 
The value of 17,179,868 is attained by solving: 0.0040 = x / 4,294,967,295 (max uint32)


# Specification
Param: MaxWeightValue
Initial Value: 4,294,967,295
Suggested Value: 17,179,868
Time of Effect: 11th November 2022