### PR TITLE
Decrease validatorExcludeQuantile from 10 to 5

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -17,7 +17,7 @@
 | **validatorEpochLen**              | 250                  |
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 256                  |
-| **validatorExcludeQuantile**       | 10                   |
+| **validatorExcludeQuantile**       | 5                    |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 60                   |
 | **MaxWeightLimit**                 | 17_179_868           |


### PR DESCRIPTION
### Decrease `validatorExcludeQuantile` from 10 to 5

**Abstract**
This recommends a decrease of `validatorExcludeQuantile` from 10% to 5%.

**Motivation**
Validators only set weights above their locally calculated `validatorExcludeQuantile`, but this means that new registrations that start at 0 Shapley value may not have enough saturation time via the validator exponential moving average updates, in order to exceed `validatorExcludeQuantile` and get weights set before the `immunityPeriod` expires.

Recent validator analysis shows that a negligible percentage of new registrations can exceed `validatorExcludeQuantile=10`, but that if it is reduced to `validatorExcludeQuantile=5` then an appreciable percentage can survive after immunity. Lowering this threshold will also allow the deregistration mechanism to remove the worst performing servers once their protection by the high entry barrier for new registrations are removed. New registrations would only need to moderately outperform the worst performing established servers to gain entry.

**Specification**
Param: validatorExcludeQuantile
Initial Value: 10
Suggested Value: 5
Time of Effect: 15 November 2022 (projected)