### PR TITLE
Increase immunityPeriod from 3072 to 4096

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -3,7 +3,7 @@
 | **adjustmentInterval**             | 100                  |
 | **blocksPerStep**                  | 100                  |
 | **bondsMovingAverage**             | 900,000              |
-| **immunityPeriod**                 | 3072                 |
+| **immunityPeriod**                 | 4096                 |
 | **incentivePruningDenominator**    | 1                    |
 | **kappa**                          | 2                    |
 | **maxAllowedMaxMinRatio**          | 64                   |


### PR DESCRIPTION
### Increase immunityPeriod to 4096

**Abstract**
This recommends an increase of `immunityPeriod` from 3072 blocks to 4096 blocks.

**Motivation**
Newly registered keys running above average models are experiencing an increasing failure rate in staying registered, due to a combination of factors like the validator exponential moving average requiring longer time to saturate to full server scores. A further increase in the `immunityPeriod` should provide more time for new servers to be more fully evaluated in the network and reach their true scores.

We should monitor attrition rates and confirm that there are no unintended consequences from longer immunity, including key squatting where registration is not followed with bona fide incentive building or proper validation. Further `immunityPeriod` increases or other interventions may follow to complement this.

**Specification**
Param: immunityPeriod
Initial Value: 3072
Suggested Value: 4096
Time of Effect: 18 November 2022 (projected)