### PR TITLE
Increase adjustment interval

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -1,6 +1,6 @@
 | **Validator Hyperparameter**       | **Value**            |
 |------------------------------------|----------------------|
-| **adjustmentInterval**             | 100                  |
+| **adjustmentInterval**             | 135                  |
 | **blocksPerStep**                  | 100                  |
 | **bondsMovingAverage**             | 900,000              |
 | **immunityPeriod**                 | 4096                 |


### PR DESCRIPTION
The push to 4096 was desirable to help miners get in the network. 

![image](https://user-images.githubusercontent.com/5873393/203428451-a49515e9-e421-40dd-91f2-333d5b6911e1.png)

It is clear that the total number of immune peers has gone down. More specifically, the increase to 4096 came with an expected 20% increase in the number of immune. What we have expected was an additional 40% increase of 32
(by observing the exact same 40% error with the observed 3000 period).

![image](https://user-images.githubusercontent.com/5873393/203429014-c15e1617-a5ea-40ca-95b5-bf191900d084.png)


The "observed average number of immune after" compared to its "Expected number of immune". The relative difference between the two lines jumps from 40% to 58%.

We can solve this by decreasing this term or by slowing down the number of miners currently immune in that period. This is why we are increasing the adjustmentinterval. This will decrease the number of peers being registered but still gives them a good chance to stay in the network.