### PR TITLE
add chain spec properties

### DIFF
--- a/specs/nakamotoChainSpec.json
+++ b/specs/nakamotoChainSpec.json
@@ -8,7 +8,11 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "ss58Format": 13116,
+    "tokenDecimals": 9,
+    "tokenSymbol": "TAO"
+  },
   "consensusEngine": null,
   "codeSubstitutes": {},
   "genesis": {

--- a/specs/nakamotoChainSpecRaw.json
+++ b/specs/nakamotoChainSpecRaw.json
@@ -8,7 +8,11 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "ss58Format": 13116,
+    "tokenDecimals": 9,
+    "tokenSymbol": "TAO"
+  },
   "consensusEngine": null,
   "codeSubstitutes": {},
   "genesis": {

--- a/specs/nobunagaSpec.json
+++ b/specs/nobunagaSpec.json
@@ -7,7 +7,11 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "ss58Format": 13116,
+    "tokenDecimals": 9,
+    "tokenSymbol": "TAO"
+  },
   "consensusEngine": null,
   "codeSubstitutes": {},
   "genesis": {

--- a/specs/nobunagaSpecRaw.json
+++ b/specs/nobunagaSpecRaw.json
@@ -7,7 +7,11 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "ss58Format": 13116,
+    "tokenDecimals": 9,
+    "tokenSymbol": "TAO"
+  },
   "consensusEngine": null,
   "codeSubstitutes": {},
   "genesis": {


### PR DESCRIPTION
This PR adds the `properties` field to the chain specs along with our new ss58 format.  

We recently requested (and received) this new format in the parity ss58 registry: https://github.com/paritytech/ss58-registry/pull/149/files  

This change shouldn't effect any of the existing subtensor nodes, but will allow these properties/metadata to be accessible from each chain-node that uses them.  