### PR TITLE
Increasing the adjustment interval from 135 to 150

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -1,6 +1,6 @@
 | **Validator Hyperparameter**       | **Value**            |
 |------------------------------------|----------------------|
-| **adjustmentInterval**             | 135                  |
+| **adjustmentInterval**             | 150                  |
 | **blocksPerStep**                  | 100                  |
 | **bondsMovingAverage**             | 900,000              |
 | **immunityPeriod**                 | 4096                 |


### PR DESCRIPTION
Increase adjustmentInterval to 150
Abstract
This recommends an increase of adjustmentInterval from 135 blocks to 150 blocks.

Motivation
A continuation of #35, the increase in adjustInterval saw a drop in immunity peers. However, within the past two weeks, the number of immune peers have risen once again from 280 -> 306. To compensate for the increase in immune peers, we should preempt issues that we saw before and increase the adjustInterval slightly. 

Specification
Param: adjustInterval
Initial Value: 135
Suggested Value: 150
Time of Effect: 12 December 2022 (projected)