### PR TITLE
Decrease synergyScalingLawPower from 60 to 50

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -19,5 +19,5 @@
 | **validatorSequenceLength**        | 256                  |
 | **validatorExcludeQuantile**       | 5                    |
 | **scalingLawPower**                | 50                   |
-| **synergyScalingLawPower**         | 60                   |
+| **synergyScalingLawPower**         | 50                   |
 | **MaxWeightLimit**                 | 17_179_868           |


### PR DESCRIPTION
Decrease synergyScalingLawPower to 50
Abstract
This recommends a decrease of synergyScalingLawPower from 60 to 50.

Motivation:
synergyScalingLawPower controls the scaling power on the synergy calculation. Recent results have shown that some of the randomnesses in server rankings was caused by the imbalance between synergyScalingLawPower and scalingLawPower. This PR is to bring balance between the two scaling powers and reduce some of the randomnesses in the server rankings.



Specification
Param: scalingLawPower
Initial Value: 60
Suggested Value: 50
Time of Effect: 12 December 2022 (projected)