### PR TITLE
[BIT-623] Add ValidatorPruneLen & ValidatorLogitsDivergence

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -194,6 +194,14 @@ pub mod pallet {
 		/// Initial validator exclude quantile.
 		#[pallet::constant]
 		type InitialValidatorExcludeQuantile: Get<u8>;
+
+		/// Initial validator context pruning length.
+		#[pallet::constant]
+		type InitialValidatorPruneLen: Get<u64>;
+
+		/// Initial validator logits divergence penalty/threshold.
+		#[pallet::constant]
+		type InitialValidatorLogitsDivergence: Get<u64>;
 	}
 
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
@@ -585,6 +593,26 @@ pub mod pallet {
 		DefaultValidatorExcludeQuantile<T>
 	>;
 
+	#[pallet::type_value] 
+	pub fn DefaultValidatorPruneLen<T: Config>() -> u64 { T::InitialValidatorPruneLen::get() }
+	#[pallet::storage]
+	pub type ValidatorPruneLen<T> = StorageValue<
+		_, 
+		u64, 
+		ValueQuery,
+		DefaultValidatorPruneLen<T>
+	>;
+
+	#[pallet::type_value] 
+	pub fn DefaultValidatorLogitsDivergence<T: Config>() -> u64 { T::InitialValidatorLogitsDivergence::get() }
+	#[pallet::storage]
+	pub type ValidatorLogitsDivergence<T> = StorageValue<
+		_, 
+		u64, 
+		ValueQuery,
+		DefaultValidatorLogitsDivergence<T>
+	>;
+
 	/// #[pallet::type_value] 
 	/// pub fn DefaultFoundationAccount<T: Config>() -> u64 { T::InitialFoundationAccount::get() }
 	#[pallet::storage]
@@ -812,6 +840,12 @@ pub mod pallet {
 
 		/// --- Event created when the validator exclude quantile has been set.
 		ValidatorExcludeQuantileSet( u8 ),
+
+		/// --- Event created when the validator pruning length has been set.
+		ValidatorPruneLenSet( u64 ),
+
+		/// --- Event created when the validator logits divergence value has been set.
+		ValidatorLogitsDivergenceSet( u64 ),
 
 		/// --- Event created when the validator default epoch length has been set.
 		ValidatorEpochLenSet(u64),
@@ -1463,6 +1497,28 @@ pub mod pallet {
 			Self::deposit_event( Event::ValidatorExcludeQuantileSet( validator_exclude_quantile ));
 			Ok(())
 		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_validator_prune_len( 
+			origin:OriginFor<T>, 
+			validator_prune_len: u64 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+		    ValidatorPruneLen::<T>::set( validator_prune_len );
+			Self::deposit_event( Event::ValidatorPruneLenSet( validator_prune_len ));
+			Ok(())
+		}
+
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_validator_logits_divergence( 
+			origin:OriginFor<T>, 
+			validator_logits_divergence: u64 
+		) -> DispatchResult {
+			ensure_root( origin )?;
+		    ValidatorLogitsDivergence::<T>::set( validator_logits_divergence );
+			Self::deposit_event( Event::ValidatorLogitsDivergenceSet( validator_logits_divergence ));
+			Ok(())
+		}
 	}
 
 	// ---- Subtensor helper functions.
@@ -1612,6 +1668,20 @@ pub mod pallet {
 		}
 		pub fn set_validator_exclude_quantile( validator_exclude_quantile: u8 ) {
 			ValidatorExcludeQuantile::<T>::put( validator_exclude_quantile );
+		}
+
+		pub fn get_validator_prune_len( ) -> u64 {
+			return ValidatorPruneLen::<T>::get();
+		}
+		pub fn set_validator_prune_len( validator_prune_len: u64 ) {
+			ValidatorPruneLen::<T>::put( validator_prune_len );
+		}
+
+		pub fn get_validator_logits_divergence( ) -> u64 {
+			return ValidatorLogitsDivergence::<T>::get();
+		}
+		pub fn set_validator_logits_divergence( validator_logits_divergence: u64 ) {
+			ValidatorLogitsDivergence::<T>::put( validator_logits_divergence );
 		}
 
 		// -- Get step consensus shift (1/kappa)

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -199,9 +199,9 @@ impl pallet_subtensor::Config for Test {
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
-	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 	type InitialValidatorPruneLen = InitialValidatorPruneLen;
 	type InitialValidatorLogitsDivergence = InitialValidatorLogitsDivergence;
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 	type InitialScalingLawPower = InitialScalingLawPower;
 	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
 

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -94,6 +94,11 @@ parameter_types! {
 	pub const InitialValidatorSequenceLen: u64 = 10;
 	pub const InitialValidatorEpochLen: u64 = 10;
 	pub const InitialValidatorEpochsPerReset: u64 = 10;
+	pub const InitialValidatorExcludeQuantile: u8 = 10;
+	pub const InitialValidatorPruneLen: u64 = 0;
+	pub const InitialValidatorLogitsDivergence: u64 = 0;
+	pub const InitialScalingLawPower: u8 = 50;
+	pub const InitialSynergyScalingLawPower: u8 = 60;
 
 	pub const InitialMinAllowedWeights: u64 = 0;
 	pub const InitialMaxAllowedMaxMinRatio: u64 = 0;
@@ -107,10 +112,6 @@ parameter_types! {
 	pub const InitialAdjustmentInterval: u64 = 100;
 	pub const InitialMaxRegistrationsPerBlock: u64 = 2;
 	pub const InitialTargetRegistrationsPerInterval: u64 = 2;
-
-	pub const InitialScalingLawPower: u8 = 50;
-	pub const InitialSynergyScalingLawPower: u8 = 60;
-	pub const InitialValidatorExcludeQuantile: u8 = 10;
 }
 
 thread_local!{
@@ -198,10 +199,11 @@ impl pallet_subtensor::Config for Test {
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;
 	type InitialValidatorEpochsPerReset = InitialValidatorEpochsPerReset;
-	
+	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
+	type InitialValidatorPruneLen = InitialValidatorPruneLen;
+	type InitialValidatorLogitsDivergence = InitialValidatorLogitsDivergence;
 	type InitialScalingLawPower = InitialScalingLawPower;
 	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
-	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
 
 	type InitialImmunityPeriod = InitialImmunityPeriod;
 	type InitialMaxAllowedUids = InitialMaxAllowedUids;

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -94,9 +94,9 @@ parameter_types! {
 	pub const InitialValidatorSequenceLen: u64 = 10;
 	pub const InitialValidatorEpochLen: u64 = 10;
 	pub const InitialValidatorEpochsPerReset: u64 = 10;
-	pub const InitialValidatorExcludeQuantile: u8 = 10;
 	pub const InitialValidatorPruneLen: u64 = 0;
 	pub const InitialValidatorLogitsDivergence: u64 = 0;
+	pub const InitialValidatorExcludeQuantile: u8 = 10;
 	pub const InitialScalingLawPower: u8 = 50;
 	pub const InitialSynergyScalingLawPower: u8 = 60;
 

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -264,6 +264,24 @@ fn test_sudo_validator_exclude_quantile() {
     });
 }
 
+#[test]
+fn test_sudo_validator_prune_len() {
+	new_test_ext().execute_with(|| {
+        let validator_prune_len: u64 = 10;
+		assert_ok!(Subtensor::sudo_set_validator_prune_len(<<Test as Config>::Origin>::root(), validator_prune_len));
+        assert_eq!(Subtensor::get_validator_prune_len(), validator_prune_len);
+    });
+}
+
+#[test]
+fn test_sudo_validator_logits_divergence() {
+	new_test_ext().execute_with(|| {
+        let validator_logits_divergence: u64 = 10;
+		assert_ok!(Subtensor::sudo_set_validator_logits_divergence(<<Test as Config>::Origin>::root(), validator_logits_divergence));
+        assert_eq!(Subtensor::get_validator_logits_divergence(), validator_logits_divergence);
+    });
+}
+
 
 //#########################
 //## sudo failure tests ###
@@ -490,6 +508,26 @@ fn test_fails_sudo_validator_exclude_quantile() {
         let init_validator_exclude_quantile: u8 = Subtensor::get_validator_exclude_quantile();
 		assert_eq!(Subtensor::sudo_set_validator_exclude_quantile(<<Test as Config>::Origin>::signed(0), validator_exclude_quantile),  Err(DispatchError::BadOrigin.into()));
         assert_eq!(Subtensor::get_validator_exclude_quantile(), init_validator_exclude_quantile);
+    });
+}
+
+#[test]
+fn test_fails_sudo_validator_prune_len() {
+	new_test_ext().execute_with(|| {
+        let validator_prune_len: u64 = 10;
+        let init_validator_prune_len: u64 = Subtensor::get_validator_prune_len();
+		assert_eq!(Subtensor::sudo_set_validator_prune_len(<<Test as Config>::Origin>::signed(0), validator_prune_len),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_validator_prune_len(), init_validator_prune_len);
+    });
+}
+
+#[test]
+fn test_fails_sudo_validator_logits_divergence() {
+	new_test_ext().execute_with(|| {
+        let validator_logits_divergence: u64 = 10;
+        let init_validator_logits_divergence: u64 = Subtensor::get_validator_logits_divergence();
+		assert_eq!(Subtensor::sudo_set_validator_logits_divergence(<<Test as Config>::Origin>::signed(0), validator_logits_divergence),  Err(DispatchError::BadOrigin.into()));
+        assert_eq!(Subtensor::get_validator_logits_divergence(), init_validator_logits_divergence);
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -275,6 +275,8 @@ parameter_types! {
 	pub const InitialValidatorSequenceLen: u64 = 10;
 	pub const InitialValidatorEpochLen: u64 = 1000;
 	pub const InitialValidatorEpochsPerReset: u64 = 10;
+	pub const InitialValidatorPruneLen: u64 = 0;
+	pub const InitialValidatorLogitsDivergence: u64 = 0;
 	
 	// u8 where value (x) represents x * 10^-2
 	pub const InitialScalingLawPower: u8 = 50; // 0.5
@@ -314,6 +316,8 @@ impl pallet_subtensor::Config for Runtime {
 	type InitialScalingLawPower = InitialScalingLawPower;
 	type InitialSynergyScalingLawPower = InitialSynergyScalingLawPower;
 	type InitialValidatorExcludeQuantile = InitialValidatorExcludeQuantile;
+	type InitialValidatorPruneLen = InitialValidatorPruneLen;
+	type InitialValidatorLogitsDivergence = InitialValidatorLogitsDivergence;
 	type InitialValidatorBatchSize = InitialValidatorBatchSize;
 	type InitialValidatorSequenceLen = InitialValidatorSequenceLen;
 	type InitialValidatorEpochLen = InitialValidatorEpochLen;

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -17,9 +17,9 @@
 | **validatorEpochLen**              | 250                  |
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 256                  |
-| **validatorExcludeQuantile**       | 5                    |
 | **validatorPruneLen**              | 0                    |
 | **validatorLogitsDivergence**      | 0                    |
+| **validatorExcludeQuantile**       | 5                    |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 50                   |
 | **MaxWeightLimit**                 | 17_179_868           |

--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -18,6 +18,8 @@
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 256                  |
 | **validatorExcludeQuantile**       | 5                    |
+| **validatorPruneLen**              | 0                    |
+| **validatorLogitsDivergence**      | 0                    |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 50                   |
 | **MaxWeightLimit**                 | 17_179_868           |


### PR DESCRIPTION
### [BIT-623] Add ValidatorPruneLen & ValidatorLogitsDivergence

ValidatorPruneLen (u64) is the amount of tokens to randomly prune from the context in the validator.

ValidatorLogitsDivergence is a u64 value that can be used a penalty scale or threshold for logits divergence during validation.

[BIT-623]: https://opentensor.atlassian.net/browse/BIT-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ