### PR TITLE
Decrease ValidatorLogitsDivergence to 10%

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -18,7 +18,7 @@
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 256                  |
 | **validatorPruneLen**              | 1                    |
-| **validatorLogitsDivergence**      | 6148914691236517205  |
+| **validatorLogitsDivergence**      | 1844674407370955161  |
 | **validatorExcludeQuantile**       | 5                    |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 50                   |


### PR DESCRIPTION
Decrease ValidatorLogitsDivergence to 10%

#### Abstract
This recommends a decrease of ValidatorLogitsDivergence from 33.3...% to 10%.

This PR reduces `ValidatorLogitsDivergence` to 10% of u64::MAX, i.e. 1844674407370955161 .
Confirm in python via
```python
(2**64 - 1) // 10
```
1844674407370955161

#### Motivation
The validator robustness update had the purpose of eliminating clusters of servers that are overfit to the validation data, but actually have poor generalization performance. We introduced a logits divergence statistic as anomaly detector, which measures the divergence of server responses to the overall network response, and the weights get penalized to the degree that it diverges beyond two standard deviations (in the ~2% most extreme of responses).

At the time we deemed the risk of penalty to normal models to be low, based on testing on smaller models, but after reviewing its recent operation in nakamoto we have found the anomaly detection to be too sensitive. As this is a divergence measure relative to the network itself, and with the network predominantly hosting ~2.7B parameter models, it skewed statistics used in the anomaly detection such that it negatively impacts larger models.

The newly introduced subtensor hyperparameters enables on-demand control of context pruning and the logits divergence penalty, with the goal of promoting accurate generalization measurement under changing network conditions. Note that we will attempt to optimize these hyperparameters over the next couple of weeks, and that it'll take a few days for new changes to take effect on the scoring due to the exponential moving average at the validators.

#### Specification
**Param**: ValidatorLogitsDivergence
**Initial Value**: 6148914691236517205
**Suggested Value**: 1844674407370955161
**Time of Effect**: 25 Jan 2023