### PR TITLE
Decrease ValidatorLogitsDivergence to 2%

### DIFF
--- a/validator_hyperparameters.md
+++ b/validator_hyperparameters.md
@@ -18,7 +18,7 @@
 | **validatorEpochsPerReset**        | 60                   |
 | **validatorSequenceLength**        | 256                  |
 | **validatorPruneLen**              | 1                    |
-| **validatorLogitsDivergence**      | 1844674407370955161  |
+| **validatorLogitsDivergence**      | 368934881474191032   |
 | **validatorExcludeQuantile**       | 5                    |
 | **scalingLawPower**                | 50                   |
 | **synergyScalingLawPower**         | 50                   |


### PR DESCRIPTION
Decrease ValidatorLogitsDivergence to 2%

Abstract
This recommends a decrease of ValidatorLogitsDivergence from 10% to 2%.

This PR reduces ValidatorLogitsDivergence to 2% of u64::MAX, i.e. 368934881474191032.
Confirm in python via

(2**64 - 1) // 50
368934881474191032

Motivation
Previous PRs (#47) have shown great effect in reducing the divergence measure and improving the performance of larger models such as 6B and 20B. Currently at 10% divergence and div excess score 6-8, it means a reduction to 1/(1 + 6*0.1) = ~60% of true shapley value. This is still too high for larger models, as such we are decreasing it to 2%. 

Specification
Param: ValidatorLogitsDivergence
Initial Value: 1844674407370955161 
Suggested Value: 368934881474191032
Time of Effect: 30 Jan 2023